### PR TITLE
Fixed reference to extracted entities during ontology linking

### DIFF
--- a/notebooks/BBS_BBG_poc.ipynb
+++ b/notebooks/BBS_BBG_poc.ipynb
@@ -730,7 +730,7 @@
     "                'label': can[1].term,\n",
     "            }\n",
     "        return new\n",
-    "    mentions = [x['target']['selector']['value'] for x in annotations]\n",
+    "    mentions = [x['target']['selector']['exact'] for x in annotations]\n",
     "    linked_mentions = linker.link(mentions)\n",
     "    return (_(ann, can) for ann, can in zip(annotations, linked_mentions))"
    ]
@@ -858,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Fixes reference to extracted entities during ontology linking as commented by @pafonta 
 in https://github.com/BlueBrain/BlueBrainSearch/pull/55