### PR TITLE
Reduce memory footprint of entity linking for Jupyter Hub (DKE-357)

### DIFF
--- a/notebooks/BBS_BBG_poc.ipynb
+++ b/notebooks/BBS_BBG_poc.ipynb
@@ -587,8 +587,10 @@
     "\n",
     "import pickle\n",
     "\n",
-    "# import spacy  # FIXME Disabled to lower memory footprint for Jupyter Hub.\n",
-    "import faiss\n",
+    "# FIXME Disabled to lower memory footprint for Jupyter Hub.\n",
+    "# import spacy\n",
+    "# TODO Disabled to lower memory footprint for Jupyter Hub.\n",
+    "# import faiss\n",
     "\n",
     "class Candidate:\n",
     "    \n",
@@ -614,7 +616,7 @@
     "    def link(self, mentions):\n",
     "        print('WARN   Entity Linking   '\n",
     "              'Performances are low because the component is not part of the NLP pipeline.')\n",
-    "        selections = self.candidates(mentions)        \n",
+    "        selections = self.candidates(mentions)\n",
     "        return [self.disambiguate(mention, candidates)\n",
     "                for mention, candidates in zip(mentions, selections)]\n",
     "    \n",
@@ -640,29 +642,36 @@
     "    \n",
     "    def candidates(self, mentions, limit=3):\n",
     "        embeddings = self.model.transform(mentions)\n",
-    "        distances, indexes = self.index.search(embeddings.toarray(), limit)\n",
+    "        # TODO Disabled to lower memory footprint for Jupyter Hub.\n",
+    "        # distances, indexes = self.index.search(embeddings.toarray(), limit)\n",
+    "        distances, indexes = self.index.kneighbors(embeddings, limit)\n",
     "        return [[Candidate(*self.terms[i], d) for i, d in zip(indexes[k], distances[k])]\n",
     "                for k in range(len(mentions))]\n",
     "    \n",
-    "    def train(self, ontology, **kwargs):\n",
+    "    def train(self, ontology, model_params, index_params):\n",
     "        import numpy as np\n",
     "        from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "        from sklearn.neighbors import NearestNeighbors\n",
     "        self.ontology = [(k, v[0], v[1]) for k, v in ontology.items()]\n",
-    "        self.model = TfidfVectorizer(dtype=np.float32, **kwargs)\n",
+    "        self.model = TfidfVectorizer(**model_params)\n",
     "        terms = [x for _, x, _ in self.ontology]\n",
     "        embeddings = self.model.fit_transform(terms)\n",
     "        flags = np.array(embeddings.sum(axis=1) != 0).reshape(-1)\n",
     "        filtered_embeddings = embeddings[flags]\n",
     "        self.terms = [term for term, flag in zip(self.ontology, flags) if flag]\n",
-    "        self.index = faiss.IndexFlatL2(filtered_embeddings.shape[1])\n",
-    "        self.index.add(filtered_embeddings.toarray())\n",
+    "        # TODO Disabled to lower memory footprint for Jupyter Hub.\n",
+    "        # self.index = faiss.IndexFlatL2(filtered_embeddings.shape[1])\n",
+    "        # self.index.add(filtered_embeddings.toarray())\n",
+    "        self.index = NearestNeighbors(**index_params).fit(filtered_embeddings)\n",
     "    \n",
     "    def save_pretrained(self, dirpath):\n",
     "        with open(f'{dirpath}/model', 'wb') as f:\n",
     "            pickle.dump(linker.ontology, f)\n",
     "            pickle.dump(linker.terms, f)\n",
     "            pickle.dump(linker.model, f)\n",
-    "        faiss.write_index(linker.index, f'{dirpath}/index')\n",
+    "            pickle.dump(linker.index, f)\n",
+    "        # TODO Disabled to lower memory footprint for Jupyter Hub.\n",
+    "        # faiss.write_index(linker.index, f'{dirpath}/index')\n",
     "    \n",
     "    @staticmethod\n",
     "    def from_pretrained(dirpath, nlp):\n",
@@ -671,7 +680,9 @@
     "            linker.ontology = pickle.load(f)\n",
     "            linker.terms = pickle.load(f)\n",
     "            linker.model = pickle.load(f)\n",
-    "        linker.index = faiss.read_index(f'{dirpath}/index')\n",
+    "            linker.index = pickle.load(f)\n",
+    "        # TODO Disabled to lower memory footprint for Jupyter Hub.\n",
+    "        # linker.index = faiss.read_index(f'{dirpath}/index')\n",
     "        return linker"
    ]
   },
@@ -682,7 +693,7 @@
    "outputs": [],
    "source": [
     "# FIXME Disabled to lower memory footprint for Jupyter Hub.\n",
-    "# spacy_model = spacy.load('en_ner_craft_md')"
+    "spacy_model = None  # spacy.load('en_ner_craft_md')"
    ]
   },
   {
@@ -691,7 +702,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker = EntityLinker.from_pretrained('shared-data/entity-linking', None)"
+    "linker = EntityLinker.from_pretrained('shared-data/entity-linking', spacy_model)"
    ]
   },
   {
@@ -838,7 +849,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 256,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
- Add loading EntityLinker from pretrained model.
- Let tune EntityLinker model to target specific performances.
- Disable heavy bulk mode to lower memory footprint for Jupyter Hub.

After these changes and tuning the entity linking model ([download](https://drive.google.com/uc?export=download&id=1IlS9iHkPS_GJiPtYdl6qs49mJHvO8htO)):
.          | before | now
------ | ------- | -----
Model | 5.5 GB | 0.1 GB
Memory | 6 GB | 0.25 GB
Speed | 50 ms / mention | 5 ms / mention
Accuracy | [1] | [1]
Usability | complex (7 steps) | simple (3 steps)
Initialization |  105 secs | 60 secs

[1] No visible lost. I have built a small gold standard dataset with tricky cases from BBS Ontologies v0.3 to evaluate tuning. This is however not enough yet to reliably put a number for accuracy.

Note:
- A warning is displayed because of the scikit-learn version is higher on NISE's Jupyter Hub.

Related next actions:
- Synchronize with NISE to have it on the Jupyter Hub they deployed.
- Retrain model with NCIT synonyms and terms with an alternative definition.
- Adapt scikit-learn version to avoid having the warning displayed on NISE's Jupyter Hub.