### PR TITLE
EntityLinker beta release

### DIFF
--- a/notebooks/BBS_BBG_poc.ipynb
+++ b/notebooks/BBS_BBG_poc.ipynb
@@ -567,6 +567,7 @@
     "                        \"start\":\"oa:start\",\n",
     "                        \"end\":\"oa:end\",\n",
     "                        \"exact\":\"oa:exact\",\n",
+    "                        \"body\": \"oa:body\",\n",
     "                        \"label\":\"rdfs:label\",\n",
     "                        \"rdf\":\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\",\n",
     "                        \"rdfs\":\"http://www.w3.org/2000/01/rdf-schema#\",\n",


### PR DESCRIPTION
- Add support for concept aliases.
- Add support for switching between normal and bulk mode.
- Add display of number of considered concepts and aliases.
- Improve code quality.
- Fix another breaking change introduced by PR #55.

### EntitLinker beta release

**Features**
- Supports concepts aliases.
- Displays number of considered concepts and aliases.
- Supports normal and bulk mode switching with a parameter.
- Train model with `linker.train(...)`.
- Save trained model with `linker.save_pretrained(...)`.
- Load trained model with `EntityLinker.from_pretrained(...)`.
- Link mentions to concepts with `linker.link(...)`.

Note:
Unless part of the NLP pipeline (BBS), no disambiguation can be performed.
The concepts 'Aluminum' and 'Dietary Aluminum', for example, cannot then be distinguished.

**Performances**
. | .
--- | ---
Speed | 15 ms / mentions
Accuracy | NA (needs a proper gold standard)
Memory | 400 MB
Model | 150 MB
Initialization | 1 sec (from pre-trained model)
Usability | very simple (2 steps)

Note:
Not a real benchmark.
Considering 385,000 aliases with `bulk=False`, linked 5,600 mentions on a MacBook Pro 2016 (i7 3,3 GHz, 16 GB DDR3).