### PR TITLE
Faster retrieve_mining_cache for paragraph_ids

### DIFF
--- a/src/bbsearch/sql.py
+++ b/src/bbsearch/sql.py
@@ -224,10 +224,11 @@ def retrieve_mining_cache(identifiers, model_names, engine):
                 f"""
                 SELECT *
                 FROM mining_cache
-                WHERE (article_id = {a} AND paragraph_pos_in_article = {p}) AND (mining_model IN {model_names})
+                WHERE (article_id = {a} AND paragraph_pos_in_article = {p})
                 """
                 for a, p in identifiers_pars[i * batch_size: (i + 1) * batch_size]
             )
+            query_pars = f"""SELECT * FROM ({query_pars}) tt WHERE tt.mining_model IN {model_names}"""
             dfs_pars.append(pd.read_sql(query_pars, engine))
         df_pars = pd.concat(dfs_pars)
         df_pars = df_pars.sort_values(by=['article_id', 'paragraph_pos_in_article', 'start_char'])


### PR DESCRIPTION
Before this PR, with `use_cache=True` running Text Mining on whole articles was fast, but on individual paragraphs was still slow and did not scale linearly due to some intricacies in the SQL query. 

This PR fixes the problem with some caveats.

1. Conditions are mutually exclusive, so several `UNION`s are equivalent to several `OR`s.
2. `UNION` is considerably faster than `OR` in this case.
3. If `len(identifiers_pars)` is too large, we may have a too long SQL statement which overflows the max length. So we break it down into chunks of `1000` values.

### How do I test this PR?
Open the notebook and set `TEXT_MINING_URL = "http://dgx1.bbp.epfl.ch:8123"`. 
To reproduce the scaling results, use an `article_saver` defined as
```
NTOT = 3200
article_saver.state = {(i, 1) for i in range(0, NTOT // 2 + 1) }
article_saver.state.update({(i, 2) for i in range(0, NTOT // 2 + 1)})
```
and set `use_cache` in the `MiningWidget` to `True` and `False`, resp.

<img width="400" alt="Screenshot 2020-08-19 at 17 34 57" src="https://user-images.githubusercontent.com/17013890/90657995-54b42600-e243-11ea-9a5b-5fe095a43792.png">
