### PR TITLE
Fix setup.py and conf.py to auto generate metadata.json

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,13 +12,15 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
 
+import bbsearch
+
+sys.path.insert(0, os.path.abspath("."))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Blue Brain Search'
-author = 'Blue Brain Project'
+project = "Blue Brain Search"
+author = "Blue Brain Project"
 
 # -- General configuration ---------------------------------------------------
 
@@ -26,36 +28,38 @@ author = 'Blue Brain Project'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.mathjax',
-    'sphinx.ext.autodoc',
-    'sphinx.ext.doctest',
-    'sphinx.ext.napoleon',
-    'sphinx.ext.viewcode',
+    "sphinx.ext.mathjax",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx-bluebrain-theme'
+html_theme = "sphinx-bluebrain-theme"
+html_title = "Blue Brain Search"
+html_theme_options = {"metadata_distribution": "BBSearch"}
+version = bbsearch.__version__
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Do not mention module names
 add_module_names = False
 
 # Blue brain theme specific
 html_show_sourcelink = False
-html_title = 'Blue Brain Search'

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,12 @@ setup(
     author="Blue Brain Project (EPFL) - ML Team",
     author_email="bbp-ou-machinelearning@groupes.epfl.ch",
     url="https://github.com/BlueBrain/BlueBrainSearch",
+    project_urls={
+        "Source": "https://github.com/BlueBrain/BlueBrainSearch",
+        "Documentation": "https://bbpteam.epfl.ch/documentation",
+        "Tracker": "https://bbpteam.epfl.ch/project/issues/projects/BBS",
+    },
+    license="-",
     use_scm_version={
         "write_to": "src/bbsearch/version.py",
         "write_to_template": '"""The package version."""\n__version__ = "{version}"\n',


### PR DESCRIPTION
Follow-up from PR #139 .

Minimal PR to add `version` in `conf.py` and a few small info on `setup.py` so that `make html` will now automatically generate a `metadata.md` file, as described [here](https://sphinx-bluebrain-theme.readthedocs.io/en/latest/usage.html#metadata-generation). 

Notice that the presence of such `metadata.md` is required to use `docs-interal-upload` (see [here](https://bbpteam.epfl.ch/documentation/projects/docs-internal-upload/latest/index.html)).