### PR TITLE
[BBS-185] Search Widget: HTTP-500 error on first use

### DIFF
--- a/src/bbsearch/entrypoints/search_server_entrypoint.py
+++ b/src/bbsearch/entrypoints/search_server_entrypoint.py
@@ -34,7 +34,7 @@ def get_search_app():
     embeddings_path = pathlib.Path(embeddings_path)
     indices = H5.find_populated_rows(embeddings_path, "BSV")
     engine_url = f"mysql://{mysql_user}:{mysql_password}@{mysql_url}"
-    engine = sqlalchemy.create_engine(engine_url)
+    engine = sqlalchemy.create_engine(engine_url, pool_recycle=14400)
     models_list = [model.strip() for model in which_models.split(",")]
 
     server_app = SearchServer(


### PR DESCRIPTION
# About
When we do not use the search server for some time, the first query gives us an error.

From our logfile:
```
 File "/usr/local/lib/python3.6/dist-packages/bbsearch/sql.py", line 552, in run 
    results = [row[0] for row in self.connection.execute(query).fetchall()] 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 2237, in execute 
    return connection.execute(statement, *multiparams, **params) 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1003, in execute 
    return self._execute_text(object_, multiparams, params) 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1178, in _execute_text 
    parameters, 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1317, in _execute_context 
    e, statement, parameters, cursor, context 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1511, in _handle_dbapi_exception 
    sqlalchemy_exception, with_traceback=exc_info[2], from_=e 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/util/compat.py", line 182, in raise_ 
    raise exception 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/base.py", line 1277, in _execute_context 
    cursor, statement, parameters, context 
  File "/usr/local/lib/python3.6/dist-packages/sqlalchemy/engine/default.py", line 593, in do_execute 
    cursor.execute(statement, parameters) 
  File "/usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py", line 206, in execute 
    res = self._query(query) 
  File "/usr/local/lib/python3.6/dist-packages/MySQLdb/cursors.py", line 319, in _query 
    db.query(q) 
  File "/usr/local/lib/python3.6/dist-packages/MySQLdb/connections.py", line 259, in query 
    _mysql.connection.query(self, query) 
sqlalchemy.exc.OperationalError: (MySQLdb._exceptions.OperationalError) (2013, 'Lost connection to MySQL server during query') 
[SQL: SELECT sentence_id FROM sentences WHERE article_id IN ( 
                SELECT article_id 
                FROM articles 
                WHERE is_english = 1 AND journal IS NOT NULL AND publish_time BETWEEN '2000-01-01' AND '2020-12-31' 
            )] 
```

Our mysqldb has a timeout of 8 hours for a connection
```
mysql> SHOW GLOBAL VARIABLES LIKE "wait_timeout";
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| wait_timeout  | 28800 |
+---------------+-------+
```

# Solution
Setting `pool_recycle` in `sqlalchemy.create_engine` to a number of seconds that is lower than the database timeout should fix it. I set it to 4 hours.

# Links
* https://docs.sqlalchemy.org/en/14/core/engines.html#sqlalchemy.create_engine.params.pool_recycle
* https://stackoverflow.com/questions/29755228/sqlalchemy-mysql-lost-connection-to-mysql-server-during-query