### PR TITLE
[BBS-200] Wrong article hyperlinks in SearchWidget

### DIFF
--- a/src/bbsearch/widgets/search_widget.py
+++ b/src/bbsearch/widgets/search_widget.py
@@ -409,8 +409,11 @@ class SearchWidget(widgets.VBox):
         except AttributeError:
             article_auth = ""
 
-        ref = ref.split(';')[0] if ref is not None \
-            else "https://www.google.com/?q=" + quote(article_title)
+        ref = (
+            ref.split(";")[0]
+            if ref is not None
+            else "https://www.google.com/search?q=" + quote(article_title)
+        )
         section_name = section_name or ""
 
         result_info = {


### PR DESCRIPTION
This PR tries to handle the issue [BBS-200] (see [JIRA](https://bbpteam.epfl.ch/project/issues/browse/BBS-200) ticket).

It seems URL column of the `articles` table contains between 0 and 6 URLs. 
![image](https://user-images.githubusercontent.com/47669575/99967245-db732480-2d97-11eb-9bda-feea2d6eaa15.png)

- When several URLs are specified, the first one is taken. 
- If there are no URL specified for the article, the link is directly giving the google search of the title page results.  