### PR TITLE
[BBS-223] Jenkins script

### DIFF
--- a/.jenkins.sh
+++ b/.jenkins.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [ "$BUILD_DOCS" = true ]; then
   git checkout master
   git pull


### PR DESCRIPTION
# What does this PR do?
Two things, which are in fact quite unrelated to each other (I can split it in two if requested, I just thought of having only one PR because the changes are minimal).

1. Add a `.jenkins.sh` script to be executed by Jenkins, so we can track what Jenkins executes.
2. ~~As the `python3.7` is now available on BB5, this PR has linting, docs, ... run with `python3.7` rather than `python3.6`. Also, `python3.6` is not used any more for tests (i.e. remove `py36` from `envlist`). This also helps a bit with [BBS-230], as testing runtime is of course reduced.~~ 

**EDIT**: while waiting for a reply from NSE on BBP standards, this PR will do one thing only, i.e. introduce the Jenkins script.