### PR TITLE
Add zip_safe=False to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("./src"),
     package_data={"bbsearch": ["_css/stylesheet.css", "py.typed"]},
+    zip_safe=False,
     python_requires=">=3.6",
     setup_requires=["setuptools_scm"],
     install_requires=install_requires,


### PR DESCRIPTION
According to
https://mypy.readthedocs.io/en/latest/installed_packages.html#installed-packages

"If you use setuptools, you must pass the option zip_safe=False to setup(),
or mypy will not be able to find the installed package."