### PR TITLE
Ignore DVC Local Config in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,4 @@
 *.egg
 .env*
 !.env*.example
+/.dvc/config.local


### PR DESCRIPTION
We must not copy the `.dvc/config.local` file to our docker images, otherwise the DVC access might not work.

Therefore the path `.dvc/config.local` was added to `.dockerignore`.