### PR TITLE
[BBS-288] Fix URLs to BlueBrain/Search

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Fixes #{issue-id-number}.
 
 ## Checklist:
 
-- [ ] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/BlueBrainSearch/issues
+- [ ] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/Search/issues
 ) (if it is not the case, please create an issue
  first).
 - [ ] Unit tests added.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,11 @@ to read the following guidelines.
 
 ## <a name="CreatingIssues"></a> Creating Issues
 This section contains the instructions to be followed to create issues on our
-[issue tracker](https://github.com/BlueBrain/BlueBrainSearch/issues).
+[issue tracker](https://github.com/BlueBrain/Search/issues).
 
 ### <a name="Sri"></a> Search related issues
 Before you submit an issue, please search our 
-[issue tracker](https://github.com/BlueBrain/BlueBrainSearch/issues) to verify 
+[issue tracker](https://github.com/BlueBrain/Search/issues) to verify 
 if any similar issue was raised in the past. Even if you cannot find a direct
 answer to your question, this can allow you to collect a list of related issues
 that you can link in your new issue.
@@ -92,7 +92,7 @@ added to both the `setup.py` and the `requirements.txt` files.
 
 ### <a name="Udoc"></a> Update documentation
 The
-[`whatsnew.rst`](https://github.com/BlueBrain/BlueBrainSearch/blob/master/docs/source/whatsnew.rst)
+[`whatsnew.rst`](https://github.com/BlueBrain/Search/blob/master/docs/source/whatsnew.rst)
 file in our docs keeps tracks of the updates introduced in every new release,
 so you should update it if your PR adds or changes a feature, fixes a bug, etc.
 
@@ -117,4 +117,4 @@ maintainers are required for the pull request to be merged into the master.
 
 
 [ml-team-email]: mailto:bbp-ou-machinelearning@groupes.epfl.ch
-[github]: https://github.com/BlueBrain/BlueBrainSearch
+[github]: https://github.com/BlueBrain/Search

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with this program. If not, see <https://www.gnu.org/licenses/>.
 -->
-<img src="docs/source/logo/BlueBrainSearch_banner.jpg"/>
+<img src="docs/source/logo/Search_banner.jpg"/>
 
 # Blue Brain Search
 
@@ -24,7 +24,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <tr>
   <td>Latest Release</td>
   <td>
-    <a href="https://github.com/BlueBrain/BlueBrainSearch/releases">
+    <a href="https://github.com/BlueBrain/Search/releases">
     <img src="https://img.shields.io/github/v/release/BlueBrain/BlueBrainsearch" alt="Latest release" />
     </a>
   </td>
@@ -32,16 +32,16 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/BlueBrain/BlueBrainSearch/blob/master/LICENSE.txt">
-    <img src="https://img.shields.io/github/license/BlueBrain/BlueBrainSearch" alt="License" />
+    <a href="https://github.com/BlueBrain/Search/blob/master/LICENSE.txt">
+    <img src="https://img.shields.io/github/license/BlueBrain/Search" alt="License" />
     </a>
 </td>
 </tr>
 <tr>
   <td>Build Status</td>
   <td>
-    <a href="https://travis-ci.com/BlueBrain/BlueBrainSearch">
-    <img src="https://travis-ci.com/BlueBrain/BlueBrainSearch.svg?token=DiSGfujs1Bszyq2UxayG&branch=master" alt="Build status" />
+    <a href="https://travis-ci.com/BlueBrain/Search">
+    <img src="https://travis-ci.com/BlueBrain/Search.svg?token=DiSGfujs1Bszyq2UxayG&branch=master" alt="Build status" />
     </a>
   </td>
 </tr>
@@ -218,7 +218,7 @@ Then, please create a working directory and navigate to it in the command line.
 After, please clone the Blue Brain Search repository.
 
 ```bash
-git clone https://github.com/BlueBrain/BlueBrainSearch
+git clone https://github.com/BlueBrain/Search
 ```
 
 Finally, let's keep track of the path to the working directory
@@ -226,7 +226,7 @@ the repository directory, and the data and models directory.
 
 ```bash
 export WORKING_DIRECTORY="$(pwd)"
-export REPOSITORY_DIRECTORY="$WORKING_DIRECTORY/BlueBrainSearch"
+export REPOSITORY_DIRECTORY="$WORKING_DIRECTORY/Search"
 export BBS_DATA_AND_MODELS_DIR="$REPOSITORY_DIRECTORY/data_and_models"
 ```
 
@@ -428,7 +428,7 @@ cd data_and_models/pipelines/ner
 dvc pull $(< dvc.yaml grep -oE '\badd_er_[0-9]+\b' | xargs)
 ```
 
-NB: At the moment, `dvc_pull_models` from `BlueBrainSearch/docker/utils.sh`
+NB: At the moment, `dvc_pull_models` from `Search/docker/utils.sh`
 is not yet usable as it works only when inside the `bbs_` Docker containers.
 
 You will be asked to enter the MySQL root password defined above
@@ -608,8 +608,8 @@ pip install .
 
 ## Installation (Docker)
 We provide a docker file, `docker/Dockerfile` that allows to build a docker
-image with all dependencies of `BlueBrainSearch` pre-installed. Note that
-`BlueBrainSearch` itself is not installed, which needs to be done manually
+image with all dependencies of `bluesearch` pre-installed. Note that
+`bluesearch` itself is not installed, which needs to be done manually
 on each container that is spawned.
 
 To build the docker image open a terminal in the root directory of the project

--- a/docs/source/entrypoint.rst
+++ b/docs/source/entrypoint.rst
@@ -58,7 +58,7 @@ Install Blue Brain Search:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/BlueBrain/BlueBrainSearch.git
+    pip install git+https://github.com/BlueBrain/Search.git
 
 Define the path to the output HDF5 file with the embeddings:
 
@@ -115,7 +115,7 @@ Install Blue Brain Search:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/BlueBrain/BlueBrainSearch.git
+    pip install git+https://github.com/BlueBrain/Search.git
 
 Launch the creation of the database:
 

--- a/setup.py
+++ b/setup.py
@@ -81,9 +81,9 @@ setup(
     name="bluesearch",
     description="Blue Brain Search",
     author="Blue Brain Project, EPFL",
-    url="https://github.com/BlueBrain/BlueBrainSearch",
+    url="https://github.com/BlueBrain/Search",
     project_urls={
-        "Source": "https://github.com/BlueBrain/BlueBrainSearch",
+        "Source": "https://github.com/BlueBrain/Search",
         "Documentation": "https://bbpteam.epfl.ch/documentation",
         "Tracker": "https://bbpteam.epfl.ch/project/issues/projects/BBS",
     },

--- a/src/bluesearch/__init__.py
+++ b/src/bluesearch/__init__.py
@@ -1,4 +1,4 @@
-"""Package for the BlueBrainSearch project."""
+"""bluesearch: a Python package for text mining on scientific use cases."""
 
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #


### PR DESCRIPTION
## Description

After #231 we renamed the repo on GitHub as `BlueBrain/Search` from the previous `BlueBrain/BlueBrainSearch`, but we forgot to accordingly replace instances of this URL in the code.

This shouldn't break anything, but it's highly recommended that URLs are fixed, see [here](https://docs.github.com/en/github/administering-a-repository/renaming-a-repository).

Fixes [BBS-288](https://bbpteam.epfl.ch/project/issues/browse/BBS-288).


## Checklist:

- [x] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/BlueBrainSearch/issues
) (if it is not the case, please create an issue
 first).
- [x] Documentation and `whatsnew.rst` updated (if needed).