### PR TITLE
[BBS-296] Add instructions on pulling BioBERT NLI+STS CORD-19 v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Before proceeding, four things need to be noted.
 
 First, at the moment, these instructions assume that the machine is inside Blue
 Brain's network. Indeed, the models we have trained have not been publicly
-released  yet.
+released yet.
 
 Second, the setup of Blue Brain Search requires the launch of 4 servers
 (database, search, mining, notebook). The instructions are supposed to be


### PR DESCRIPTION
## Description

https://github.com/BlueBrain/Search/pull/232 has added the model `BioBERT NLI+STS CORD-19 v1` to DVC.

This PR adds instructions in the README on how to pull the model before computing the sentence embeddings.

More precisely:

- Add the `dvc pull` instructions for BioBERT NLI+STS CORD-19 v1.
- Add a dedicated part to configure DVC as now it is used in two places.
- Harmonize the use of `cd`.
- Fix forgotten use of `BBS_DATA_AND_MODELS_DIR`.

## How to test?

The following instructions should work fine:

```
export USER_NAME=$(id -un)
export BBS_SSH_USERNAME=$USER_NAME

git clone --branch pull_biobert_cord19 https://github.com/BlueBrain/Search.git

export WORKING_DIRECTORY="$(pwd)"
export REPOSITORY_DIRECTORY="$WORKING_DIRECTORY/Search"
export BBS_DATA_AND_MODELS_DIR="$REPOSITORY_DIRECTORY/data_and_models"

export DATABASE_URL=dgx1.bbp.epfl.ch:8953/cord19

docker run \
  --volume /raid:/raid \
  --env REPOSITORY_DIRECTORY \
  --env WORKING_DIRECTORY \
  --env DATABASE_URL \
  --env BBS_SSH_USERNAME \
  --env BBS_DATA_AND_MODELS_DIR \
  --gpus all \
  --interactive \
  --tty \
  --rm \
  --user "$USER_NAME" \
  --name bbs_base_${USER_NAME} bbs_base

cd $REPOSITORY_DIRECTORY

pip install .

dvc remote modify gpfs_ssh ask_password true
dvc remote modify gpfs_ssh user $BBS_SSH_USERNAME

export EMBEDDING_MODEL='BioBERT NLI+STS CORD-19 v1'
export BBS_SEARCH_EMBEDDINGS_PATH=$WORKING_DIRECTORY/embeddings.h5

cd $BBS_DATA_AND_MODELS_DIR/models/sentence_embedding/
dvc pull biobert_nli_sts_cord19_v1

compute_embeddings SentTransformer $BBS_SEARCH_EMBEDDINGS_PATH \
  --checkpoint biobert_nli_sts_cord19_v1 \
  --db-url $DATABASE_URL \
  --gpus 0,1 \
  --h5-dataset-name "$EMBEDDING_MODEL" \
  --n-processes 2
```

Note: The instructions are coming from the README. They are adapted to focus only on the part to test (computing sentence embeddings).

## Checklist:

- [x] This PR refers to an issue present in the issue tracker.
- [x] Travis CI pipeline run.