### PR TITLE
[BBS-301] Fix license badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <tr>
   <td>License</td>
   <td>
-    <a href="https://github.com/BlueBrain/Search/blob/master/LICENSE.txt">
+    <a href="https://github.com/BlueBrain/Search/blob/master/COPYING.LESSER">
     <img src="https://img.shields.io/github/license/BlueBrain/Search" alt="License" />
     </a>
 </td>


### PR DESCRIPTION
## Description

Fix license badge link after #252 changed the license filename.
Fixes BBS-301.


## Checklist:

- [x] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/Search/issues
) (if it is not the case, please create an issue
 first).