### PR TITLE
[BBS-303] Link STS_evaluation.ipynb and the Getting Started

### DIFF
--- a/notebooks/STS_evaluation.ipynb
+++ b/notebooks/STS_evaluation.ipynb
@@ -45,7 +45,23 @@
     "2. Sample randomly a subset of N of them.\n",
     "3. Pair the subset with the most similar ones.\n",
     "4. Compute a word-based similarity for each pair.\n",
-    "5. Print & Export pairs in a human-readable format."
+    "5. Print & Export pairs in a human-readable format.\n",
+    "\n",
+    "**Getting Started**\n",
+    "\n",
+    "This notebook requires that:\n",
+    "\n",
+    "- a database of sentences has been created.\n",
+    "- sentence embeddings have been computed.\n",
+    "\n",
+    "The logic in the notebook is agnostic of the dataset and the model.\n",
+    "Any dataset of sentences and any sentence embedding model could be used.\n",
+    "\n",
+    "However, for demonstration purposes, we reuse below the dataset and the model from the `README`.\n",
+    "This means that we reuse the values of:\n",
+    "\n",
+    "- `DATABASE_URL` from [Create the database](https://github.com/BlueBrain/Search#initialize-the-database-server),\n",
+    "- `EMBEDDING_MODEL` and `BBS_SEARCH_EMBEDDINGS_PATH` from [Compute the sentence embeddings](https://github.com/BlueBrain/Search#compute-the-sentence-embeddings)."
    ]
   },
   {
@@ -61,6 +77,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "# Number of sentence pairs to sample.\n",
     "N = 100\n",
     "\n",
@@ -72,21 +90,28 @@
     "# File path to a dump of all the sentences.\n",
     "# This allows a faster loading of the sentences.\n",
     "# If None, sentences are loaded from the DATABASE (see below).\n",
-    "DUMP = 'sentences-cord19_v47-2020-10-01.parquet'\n",
+    "# Example: 'sentences.parquet'.\n",
+    "DUMP = None\n",
     "\n",
     "# Sentence embedding model to use for guiding pairing.\n",
-    "# A key in the EMBEDDINGS file (see below), e.g. 'Sent2Vec', BSV'.\n",
-    "MODEL = 'Sent2Vec'\n",
+    "# A key in the EMBEDDINGS file (see below).\n",
+    "# Example: 'Sent2Vec'.\n",
+    "MODEL = os.getenv('EMBEDDING_MODEL')\n",
+    "print(f\"MODEL='{MODEL}'\")\n",
     "\n",
     "# Seed for reproducibility of the random sampling.\n",
     "SEED = 9173\n",
     "\n",
     "# SQLAlchemy database URL.\n",
-    "DATABASE = 'mysql+pymysql://guest:guest@dgx1.bbp.epfl.ch:8853/cord19_v47'\n",
+    "# Example: '<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>'.\n",
+    "DATABASE = f\"mysql+pymysql://guest:guest@{os.getenv('DATABASE_URL')}\"\n",
+    "print(f\"DATABASE='{DATABASE}'\")\n",
     "\n",
     "# Path to the pre-computed sentence embeddings.\n",
     "# They must be indexed on the sentence_id from the DATABASE (see above).\n",
-    "EMBEDDINGS = '/raid/sync/proj115/bbs_data/cord19_v47/embeddings/embeddings.h5'"
+    "# Example: './embeddings.h5'.\n",
+    "EMBEDDINGS = os.getenv('BBS_SEARCH_EMBEDDINGS_PATH')\n",
+    "print(f\"EMBEDDINGS='{EMBEDDINGS}'\")"
    ]
   },
   {
@@ -164,7 +189,7 @@
    "outputs": [],
    "source": [
     "# Create a dump of the sentences.\n",
-    "# sentences.to_parquet('sentences-cord19_v47-2020-10-01.parquet', index=True)\n",
+    "# sentences.to_parquet('sentences.parquet', index=True)\n",
     "\n",
     "# Takes 20 secs for 20.5 millions sentences."
    ]
@@ -594,7 +619,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

https://github.com/BlueBrain/Search/pull/247 removed the model `Sent2Vec`.

This model was used in the notebook `STS_evaluation.ipynb`.

The PR replaces this by making use of the setup done in the `Getting Started` from the README.

Fixes [BBS-303](https://bbpteam.epfl.ch/project/issues/browse/BBS-303).

## How to test?

Follow the instructions from the [Getting Started](https://github.com/BlueBrain/Search/tree/b230221c6a086036f3709ea8232c8d4a4597d969#getting-started) but:
1. only until the end of the section [Compute the sentence embeddings](https://github.com/BlueBrain/Search/tree/b230221c6a086036f3709ea8232c8d4a4597d969#compute-the-sentence-embeddings),
2. and with the modifications below,

In [Prerequisites](https://github.com/BlueBrain/Search/tree/b230221c6a086036f3709ea8232c8d4a4597d969#prerequisites):

Replace

```
git clone https://github.com/BlueBrain/Search.git
```

by

```
git clone --branch bbs_303 https://github.com/BlueBrain/Search.git
```

In [Install Blue Brain Search](https://github.com/BlueBrain/Search/tree/b230221c6a086036f3709ea8232c8d4a4597d969#install-blue-brain-search):

As the FIRST command of this section, execute the following as a temporary fix for https://github.com/BlueBrain/Search/pull/255:

```
sed -i 's/numpy==1.20.1/numpy/g' requirements.txt
sed -i 's/numpy>=1.20.1/numpy/g' setup.py
```

Replace


```
docker run \
  --volume /raid:/raid \
  --env REPOSITORY_DIRECTORY \
  --env CORD19_DIRECTORY \
  --env WORKING_DIRECTORY \
  --env DATABASE_URL \
  --env BBS_SSH_USERNAME \
  --env BBS_DATA_AND_MODELS_DIR \
  --gpus all \
  --interactive \
  --tty \
  --rm \
  --user "$USER_NAME" \
  --name test_bbs_base test_bbs_base
```

by


```
docker run \
  --publish $NOTEBOOK_PORT:8888 \
  --volume /raid:/raid \
  --env REPOSITORY_DIRECTORY \
  --env CORD19_DIRECTORY \
  --env WORKING_DIRECTORY \
  --env DATABASE_URL \
  --env BBS_SSH_USERNAME \
  --env BBS_DATA_AND_MODELS_DIR \
  --env NOTEBOOK_TOKEN \
  --gpus all \
  --interactive \
  --tty \
  --rm \
  --user "$USER_NAME" \
  --name test_bbs_base test_bbs_base
```

After the end of the section [Compute the sentence embeddings](https://github.com/BlueBrain/Search/tree/b230221c6a086036f3709ea8232c8d4a4597d969#compute-the-sentence-embeddings):

Execute the following:

```
cd $REPOSITORY_DIRECTORY

jupyter lab notebooks --NotebookApp.token=$NOTEBOOK_TOKEN
```

Then, hit `CTRL+P` and then `CTRL+Q` to detach from the Docker container.

Finally, open and execute the notebook accessible at:

```
echo http://$HOSTNAME:$NOTEBOOK_PORT/lab/tree/STS_evaluation.ipynb?token=$NOTEBOOK_TOKEN
```

The notebook `STS_evaluation.ipynb` should run without errors until the following cell. It should display 3 lines.

```
pairs.head(3)
```

## Checklist

- [x] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Travis CI pipeline run.