### PR TITLE
[BBS-240] Make Blue Brain Search citable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 <table>
 <tr>
+  <td>DOI</td>
+  <td>
+    <a href="https://doi.org/10.5281/zenodo.4563998">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4563998.svg" alt="DOI">
+    </a>
+  </td>
+</tr>
+<tr>
   <td>Latest Release</td>
   <td>
     <a href="https://github.com/BlueBrain/Search/releases">

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 <table>
 <tr>
-  <td>DOI</td>
+  <td>Source Code DOI</td>
   <td>
     <a href="https://doi.org/10.5281/zenodo.4563998">
     <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4563998.svg" alt="DOI">

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -30,6 +30,8 @@ Legend
 Version 0.1.0
 =============
 - |Add| support for :code:`Python 3.9`.
+- |Add| Blue Brain Search as a Zenodo record. This provides a unique DOI, a DOI
+  for each published release, and automatic preservation outside GitHub.
 - |Remove| support for :code:`Python 3.6`.
 - |Remove| the external dependency :code:`sent2vec` and the embedding models
   depending on it, i.e. :code:`BSV` and :code:`Sent2VecModel`.


### PR DESCRIPTION
Fixes [BBS-240](https://bbpteam.epfl.ch/project/issues/browse/BBS-240).

## Description

This PR adds the DOI badge to the [Zenodo record](https://zenodo.org/record/4563999) of Blue Brain Search.

Each time a release is published on GitHub, an archive of the release will be uploaded on Zenodo.

Such archive will get a unique DOI. So, each release is uniquely citable.

A DOI is also assigned to the Zenodo record. This DOI points to the latest released version.

This is the DOI from the badge.

## Checklist

- [x] This PR refers to an issue present in the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Documentation and `whatsnew.rst` updated.
- [x] Travis CI pipeline run.