### PR TITLE
[BBS-266] Adapt Getting Started for DVC remote from Zenodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,9 +444,6 @@ cd $BBS_DATA_AND_MODELS_DIR/pipelines/ner/
 dvc pull $(< dvc.yaml grep -oE '\badd_er_[0-9]+\b' | xargs)
 ```
 
-NB: At the moment, `dvc_pull_models` from `Search/docker/utils.sh`
-is not yet usable as it works only when inside the `bbs_` Docker containers.
-
 You will be asked to enter the MySQL root password defined above
 (`DATABASE_PASSWORD`).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   <td>Source Code DOI</td>
   <td>
     <a href="https://doi.org/10.5281/zenodo.4563998">
-    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4563998.svg" alt="DOI">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4563998.svg" alt="Source code DOI">
+    </a>
+  </td>
+</tr>
+<tr>
+  <td>Data & Models DOI</td>
+  <td>
+    <a href="https://doi.org/10.5281/zenodo.4589006">
+    <img src="https://zenodo.org/badge/DOI/10.5281/zenodo.4589006.svg" alt="Data & Models DOI">
     </a>
   </td>
 </tr>
@@ -204,7 +212,7 @@ Otherwise, let's start in a newly created directory.
 First, download the snapshot of the DVC remote and extract it.
 
 ```bash
-wget <fixme>
+wget https://zenodo.org/record/4589007/files/bbs_dvc_remote.tar.gz
 tar xf bbs_dvc_remote.tar.gz
 ```
 

--- a/docker/mining.sh
+++ b/docker/mining.sh
@@ -18,8 +18,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 source /src/docker/utils.sh
-ssh_check
-dvc_pull_models
+# Commented to allow the use of a DVC remote from a different type than SSH.
+# ssh_check
+# Not usable in README as it works only when inside the `bbs_` containers.
+# dvc_pull_models
 
 # Launch mining server
 gunicorn --bind 0.0.0.0:8080 --workers 1 --timeout 7200 'bluesearch.entrypoint:get_mining_app()'

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -34,6 +34,9 @@ Version 0.1.0
 - |Add| support for :code:`Python 3.9`.
 - |Add| Blue Brain Search as a Zenodo record. This provides a unique DOI, a DOI
   for each published release, and automatic preservation outside GitHub.
+- |Add| the content of the DVC remote for Blue Brain Search v0.1.0 as a Zenodo
+  record. This provides DOIs as for the code of Blue Brain Search above. This
+  is also the first public release of the data and models of Blue Brain Search.
 - |Remove| support for :code:`Python 3.6`.
 - |Remove| the external dependency :code:`sent2vec` and the embedding models
   depending on it, i.e. :code:`BSV` and :code:`Sent2VecModel`.


### PR DESCRIPTION
Fixes [BBS-266](https://bbpteam.epfl.ch/project/issues/browse/BBS-266).

## TODO

~Currently blocked by [BBS-306](https://bbpteam.epfl.ch/project/issues/browse/BBS-306).~

Otherwise, after the tests are successful:
- [x] upload the TAR to Zenodo,
- [x] put the link in the instructions,
- [x] PR checklist below.

## Description

Adapt the Getting Started from the `README` to use the DVC remote from Zenodo.

## How to test?

### 1 - Getting Started

Follow the Getting Stared from the `README` after

```
git clone --depth 1 --branch bbs_266 https://github.com/BlueBrain/Search.git
```

The notebook at the end should be usable for search and mining.

### 2 - DVC

#### a) Setup

```
wget <fixme>
tar xf bbs_dvc_remote.tar.gz

git clone --depth 1 --branch v0.1.0 https://github.com/BlueBrain/Search.git

cd Search/

cp /path/to/prodigy/wheel .

dvc remote add --default local ../bbs_dvc_remote
```

#### b) Pulling

```
dvc pull
```

should retrieve all DVC tracked data and models successfully.

#### c) `pipelines/sentence_embedding`

After

```
docker build -f data_and_models/pipelines/sentence_embedding/Dockerfile -t <image_name> .
docker run -v /raid:/raid -it --rm --name <container_name> <image_name>
cd data_and_models/pipelines/sentence_embedding
dvc repro -f
```

the command

```
git diff
```

should show no change.

#### d) `pipelines/ner`

After

```
docker build -f data_and_models/pipelines/ner/Dockerfile -t <image_name> .
docker run -v /raid:/raid -it --rm --name <container_name> <image_name>
cd data_and_models/pipelines/ner
dvc repro -f
```

the command

```
git diff
```

should show no change but it will show these changes

```
--- a/data_and_models/pipelines/ner/dvc.lock
+++ b/data_and_models/pipelines/ner/dvc.lock
@@ -130,7 +130,7 @@ eval_disease:
   - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+    md5: a51a1dc7148255d3fb0e1f5b05079ec0.dir
     size: 100183520
     nfiles: 18
@@ -398,7 +398,7 @@ add_er_1:
   - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+    md5: a51a1dc7148255d3fb0e1f5b05079ec0.dir
     size: 100183520
     nfiles: 18
```

This issue isn't introduced by the current PR. This is already the situation on `master`. 

Indeed, the issue is semi-reproducible (see https://github.com/BlueBrain/Search/pull/267#issuecomment-792942855) outside this PR like this

```
git clone --depth 1 --branch v0.1.0 https://github.com/BlueBrain/Search.git
cd Search/
cp /path/to/prodigy/wheel .
docker build -f data_and_models/pipelines/ner/Dockerfile -t <image_name> .
docker run -v /raid:/raid -it --rm --name <container_name> <image_name>
dvc remote modify gpfs_ssh ask_password true
dvc remote modify gpfs_ssh user <user_name>
dvc pull
cd data_and_models/pipelines/ner
dvc repro -f
git diff dvc.lock
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Documentation and `whatsnew.rst` updated.
- [x] All CI tests pass. 