### PR TITLE
[BBS 307] EntityRuler labels nondeterministic sorting

### DIFF
--- a/data_and_models/pipelines/ner/add_er.py
+++ b/data_and_models/pipelines/ner/add_er.py
@@ -19,6 +19,7 @@
 
 from argparse import ArgumentParser
 import pathlib
+from unittest.mock import PropertyMock, patch
 
 import spacy
 import yaml
@@ -69,8 +70,13 @@ def main():
     er.add_patterns(modified_patterns)
     ner_model.add_pipe(er, after="ner")
 
-    print("Saving model with an entity ruler")
-    ner_model.to_disk(args.output_file)
+    sorted_labels = tuple(sorted(er.labels))
+
+    with patch("spacy.pipeline.EntityRuler.labels", new_callable=PropertyMock) as mock:
+        mock.return_value = sorted_labels
+
+        print("Saving model with an entity ruler")
+        ner_model.to_disk(args.output_file)
 
 
 if __name__ == "__main__":

--- a/data_and_models/pipelines/ner/add_er.py
+++ b/data_and_models/pipelines/ner/add_er.py
@@ -72,6 +72,7 @@ def main():
 
     sorted_labels = tuple(sorted(er.labels))
 
+    # See https://github.com/explosion/spaCy/issues/7352 for more info
     with patch("spacy.pipeline.EntityRuler.labels", new_callable=PropertyMock) as mock:
         mock.return_value = sorted_labels
 


### PR DESCRIPTION
# Description
It seems like `spacy` does not guarantee that labels (entity types) of the `EntityRuler` are sorted deterministically. This becomes a problem when we are saving the model because each time the `meta.json` might have a different MD5 hash.

# More detailed description

`spacy` uses the `set` datastructure to create all the labels ([actual code](https://github.com/explosion/spaCy/blob/97bcf2ae3a03cf97fd473062c1793e3d18ef2820/spacy/pipeline/entityruler.py#L180))
```python
@property
def labels(self) -> Tuple[str, ...]:
    """All labels present in the match patterns.
    RETURNS (set): The string labels.
    DOCS: https://spacy.io/api/entityruler#labels
    """
    keys = set(self.token_patterns.keys())
    keys.update(self.phrase_patterns.keys())
    all_labels = set()

    for l in keys:
        if self.ent_id_sep in l:
            label, _ = self._split_label(l)
            all_labels.add(label)
        else:
            all_labels.add(l)
    return tuple(all_labels)
```
The above can be more or less seen as doing something like:
```bash
python -c "print(tuple(set({'DISEASE': 1, 'NaE': 2})))"
```
The order can be different in general for different runs!!

I created an issue (+PR) in the `spacy` repo https://github.com/explosion/spaCy/issues/7352.

# TODO
- [x] Patch the `labels` property inside of `Search/data_and_models/pipelines/ner/add_er.py` to make sure the entity types are ordered (alphabetically)
- [x] Create a PR in the official `spacy` repository to fix this issue (without hacks)