### PR TITLE
[BBS-255] Generalize DVC initialization to not only src/ context

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,6 @@ export BBS_MINING_MYSQL_PASSWORD=guest
 docker run \
   --publish $MINING_PORT:8080 \
   --volume /raid:/raid \
-  --env BBS_DATA_AND_MODELS_DIR \
   --env BBS_MINING_DB_TYPE \
   --env BBS_MINING_DB_URL \
   --env BBS_MINING_MYSQL_USER \

--- a/docker/mining.Dockerfile
+++ b/docker/mining.Dockerfile
@@ -32,5 +32,5 @@ RUN chmod -R a+rwX /src
 
 # Run the entry point
 EXPOSE 8080
-ENV DATA_DIR="/src/data_and_models"
+ENV BBS_DATA_AND_MODELS_DIR="/src/data_and_models"
 ENTRYPOINT ["/src/docker/mining.sh"]

--- a/docker/mining.Dockerfile
+++ b/docker/mining.Dockerfile
@@ -22,13 +22,11 @@ USER root
 # Install the app
 ADD . /src
 WORKDIR /src
-ENV DATA_DIR="/src/data_and_models"
 RUN pip install -e .
 
 # Set image version
 LABEL maintainer="BBP-EPFL Machine Learning team <bbp-ou-machinelearning@groupes.epfl.ch>"
 LABEL description="REST API Server for Test Mining"
-
 
 RUN chmod -R a+rwX /src
 
@@ -37,4 +35,5 @@ RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
 
 # Run the entry point
 EXPOSE 8080
+ENV DATA_DIR="/src/data_and_models"
 ENTRYPOINT ["/src/docker/mining.sh"]

--- a/docker/mining.sh
+++ b/docker/mining.sh
@@ -18,8 +18,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 source /src/docker/utils.sh
-ssh_check
-dvc_pull_models
+dvc_configure_ssh_remote_authentication "$BBS_SSH_USERNAME"
+dvc_pull_models "$DATA_DIR"
 
 # Launch mining server
 gunicorn --bind 0.0.0.0:8080 --workers 1 --timeout 7200 'bluesearch.entrypoint:get_mining_app()'

--- a/docker/mining.sh
+++ b/docker/mining.sh
@@ -22,7 +22,7 @@ source /src/docker/utils.sh
 dvc_configure_ssh_remote_authentication "$BBS_SSH_USERNAME"
 # Not usable in README as it works only when inside the `bbs_` containers.
 # If $DATA_DIR is empty then this will fail
-dvc_pull_models "$DATA_DIR"
+dvc_pull_models "$BBS_DATA_AND_MODELS_DIR"
 
 # Launch mining server
 gunicorn --bind 0.0.0.0:8080 --workers 1 --timeout 7200 'bluesearch.entrypoint:get_mining_app()'

--- a/docker/mining.sh
+++ b/docker/mining.sh
@@ -18,9 +18,10 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 source /src/docker/utils.sh
-# Commented to allow the use of a DVC remote from a different type than SSH.
+# If $BBS_SSH_USERNAME is empty then this is a no-op
 dvc_configure_ssh_remote_authentication "$BBS_SSH_USERNAME"
 # Not usable in README as it works only when inside the `bbs_` containers.
+# If $DATA_DIR is empty then this will fail
 dvc_pull_models "$DATA_DIR"
 
 # Launch mining server

--- a/docker/mining_cache.Dockerfile
+++ b/docker/mining_cache.Dockerfile
@@ -35,4 +35,5 @@ RUN chmod -R a+rwX /src
 RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
 
 # Run the entry point
+ENV DATA_DIR="/src/data_and_models"
 ENTRYPOINT ["/src/docker/mining_cache.sh"]

--- a/docker/mining_cache.sh
+++ b/docker/mining_cache.sh
@@ -18,8 +18,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 source /src/docker/utils.sh
-ssh_check
-dvc_pull_models
+dvc_configure_ssh_remote_authentication "$BBS_SSH_USERNAME"
+dvc_pull_models "$DATA_DIR"
 
 # Launch mining cache creation, using arguments only if defined
 create_mining_cache \


### PR DESCRIPTION
JIRA: [BBS-255](https://bbpteam.epfl.ch/project/issues/browse/BBS-255)

Potentially related: [BBS-306](https://bbpteam.epfl.ch/project/issues/browse/BBS-306)

# Changes
The main change is to replace the calls
```bash
ssh_check
dvc_pull_models
```
in `docker/mining.sh` and `docker/mining_cache.sh` by
```bash
dvc_configure_ssh_remote_authentication "$BBS_SSH_USERNAME"
dvc_pull_models "$DATA_DIR"
```

This eliminates hard-coded paths in thses functions and allows to re-use them elsewhere with different parameters.

# Notes
In our `README.md` file we do the steps covered by `dvc_configure_ssh_remote_authentication` and `dvc_pull_models` manually. There's also a passage saying that "NB: At the moment, `dvc_pull_models` from `Search/docker/utils.sh` is not yet usable as it works only when inside the `bbs_` Docker containers."

Probably now this can be adjusted to use `dvc_configure_ssh_remote_authentication` and `dvc_pull_models`. I'm not 100% comforatable doing this, maybe someone else can help out?

# How to Test
```bash
docker build -f docker/mining.Dockerfile -t test_mining_server .
docker run --rm -it --env-file .env -v /raid:/raid test_mining_server
docker rmi test_mining_server
```
Make sure the DVC SSH remote is configured with the correct user name, the DVC pull is successful, and the mining server is initialised correctly.

The same test can be done with the minig cache container (using `docker/mining_cache.Dockerfile`) but make sure not to overwrite the production mining cache.