### PR TITLE
Use PyPI badge for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 <tr>
   <td>Latest Release</td>
   <td>
-    <a href="https://github.com/BlueBrain/Search/releases">
-    <img src="https://img.shields.io/github/v/release/BlueBrain/BlueBrainsearch" alt="Latest release" />
-    </a>
+        <a href="https://pypi.org/project/bluesearch/">
+        <img alt="PyPI" src="https://img.shields.io/pypi/v/bluesearch?color=blue">
+        </a>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Tiny change, just replacing GitHub Releases badge with PyPI one.

**Rationale**: We are now publishing our package with PyPI, so there does not seem to be reasons to use GitHub Releases any more.