### PR TITLE
[SUGGESTION] Add a badge for supported Python versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
   </td>
 </tr>
 <tr>
+  <td>Python Versions</td>
+  <td>
+    <img src="https://img.shields.io/pypi/pyversions/bluesearch" alt="Python Versions" />
+    </a>
+  </td>
+</tr>
+<tr>
   <td>License</td>
   <td>
     <a href="https://github.com/BlueBrain/Search/blob/master/COPYING.LESSER">


### PR DESCRIPTION
## Description

Just add a badge for supported Python versions.

This helps people to figure out compatibility with their Python environment.

## How to test?

Render the changed README. The badge should display Python 3.7 to 3.9.