### PR TITLE
Remove NLTK Dependencies

### DIFF
--- a/data_and_models/pipelines/sentence_embedding/eval.py
+++ b/data_and_models/pipelines/sentence_embedding/eval.py
@@ -57,9 +57,6 @@ args = parser.parse_args()
 
 
 def main():
-    import nltk
-    nltk.download("punkt")
-
     print("Reading params.yaml...")
     params = yaml.safe_load(open("params.yaml"))["eval"][args.model]
     module = importlib.import_module("bluesearch.embedding_models")

--- a/docker/embedding.Dockerfile
+++ b/docker/embedding.Dockerfile
@@ -33,9 +33,6 @@ RUN useradd --create-home serveruser
 WORKDIR /home/serveruser
 USER serveruser
 
-# Download the NLTK libraries (for the current user)
-RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
-
 # Run the entry point
 EXPOSE 8080
 ENTRYPOINT [\

--- a/docker/mining.Dockerfile
+++ b/docker/mining.Dockerfile
@@ -32,9 +32,6 @@ LABEL description="REST API Server for Test Mining"
 
 RUN chmod -R a+rwX /src
 
-# Download the NLTK libraries (for the current user)
-RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
-
 # Run the entry point
 EXPOSE 8080
 ENTRYPOINT ["/src/docker/mining.sh"]

--- a/docker/mining_cache.Dockerfile
+++ b/docker/mining_cache.Dockerfile
@@ -31,8 +31,5 @@ LABEL description="Creation of a Mining Cache for the Mining Server"
 
 RUN chmod -R a+rwX /src
 
-# Download the NLTK libraries (for the current user)
-RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
-
 # Run the entry point
 ENTRYPOINT ["/src/docker/mining_cache.sh"]

--- a/docker/search.Dockerfile
+++ b/docker/search.Dockerfile
@@ -33,9 +33,6 @@ RUN useradd --create-home serveruser
 WORKDIR /home/serveruser
 USER serveruser
 
-# Download the NLTK libraries (for the current user)
-RUN python -c "import nltk; nltk.download('punkt'); nltk.download('stopwords')"
-
 # Run the entry point
 # Note the "timeout" parameter. That's to let the server initialisation finish before
 # gunicorn decides that the worker is not responsive and restarts it again.

--- a/docker/utils.sh
+++ b/docker/utils.sh
@@ -76,17 +76,10 @@ configure_jupyter() {
   echo 'c.ExtensionApp.open_browser = False' >> "$HOME/.jupyter/jupyter_lab_config.py"
 }
 
-download_nltk() {
-  python -c 'import nltk; nltk.download(["punkt", "stopwords"])'
-}
-
 configure_user() {
   # If this directory doesn't exist it won't be included in the $PATH
   # and python entrypoints for user-installed packages won't work
   mkdir -p "$HOME/.local/bin"
-
-  # pre-download the nltk data
-  download_nltk
 
   # miscellaneous tweaks and settings
   add_aliases
@@ -111,7 +104,7 @@ create_users() {
     user_id="${x#*/}"
     user_home="/home/${user_name}"
     useradd --create-home --uid "$user_id" --gid "$GROUP" --home-dir "$user_home" "$user_name"
-    su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt configure_jupyter download_nltk) &&  configure_user"
+    su "$user_name" -c "$(declare -f configure_user add_aliases improve_prompt configure_jupyter) &&  configure_user"
     echo "Added user ${user_name} with ID ${user_id}"
   done
 }

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -26,6 +26,9 @@ Legend
 - |Deprecate| denotes deprecated features that will be removed in the future.
 - |Remove| denotes removed features.
 
+Latest
+======
+- |Remove| NLTK dependencies
 
 Version 0.1.0
 =============

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,6 @@ jupyterlab==3.0.9
 langdetect==1.0.8
 matplotlib==3.3.4
 mysqlclient==2.0.3
-nltk==3.5
 numpy==1.20.1
 pandas==1.2.2
 pdfkit==0.6.1

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ INSTALL_REQUIRES = [
     "langdetect",
     "matplotlib",
     "mysqlclient",
-    "nltk",
     "numpy>=1.20.1",
     "pandas>=1.0.0",
     "pdfkit",

--- a/tox.ini
+++ b/tox.ini
@@ -29,13 +29,10 @@ envlist =
 
 [testenv]
 download = true
-deps =
-    en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz
+deps = en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz
 extras = dev
 allowlist_externals = docker
-commands =
-    python -m nltk.downloader stopwords punkt
-    pytest {posargs:tests}
+commands = pytest {posargs:tests}
 
 [testenv:lint]
 basepython = python3.7


### PR DESCRIPTION
Fixes #292 

## Description

Remove all NLTK dependencies since we don't use it any more.

## How to test?
I did the following grep on our code base:
```bash
find . -type f ! -path './.*' ! -path './venv/*' | xargs grep -in nltk
```
Any other places NLTK could be?

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
