### PR TITLE
Fix the has_table call

### DIFF
--- a/src/bluesearch/database/mining_cache.py
+++ b/src/bluesearch/database/mining_cache.py
@@ -279,7 +279,7 @@ class CreateMiningCache:
         self.logger = logging.getLogger(self.__class__.__name__)
         required_tables = ["articles", "sentences"]
         for table_name in required_tables:
-            if not database_engine.dialect.has_table(database_engine, table_name):
+            if not database_engine.has_table(table_name):
                 raise ValueError(
                     f"Database at {database_engine.url} does not "
                     f"contain required table {table_name}."
@@ -322,7 +322,7 @@ class CreateMiningCache:
         """Create the schemas of the different tables in the database."""
         metadata = sqlalchemy.MetaData()
 
-        if self.engine.dialect.has_table(self.engine, self.target_table):
+        if self.engine.has_table(self.target_table):
             self.mining_cache_table = sqlalchemy.Table(
                 self.target_table, metadata, autoload=True, autoload_with=self.engine
             )


### PR DESCRIPTION
Fixes #300 .

## Description

With the latest SQLAlchemy version `1.4.0` the following call leads to an exception:
```python
engine.dialect.has_table(engine, table_name)
```

It can be fixed by replacing it with
```python
engine.has_table(table_name)
```

## How to test?
```bash
pip install sqlalchemy==1.4.0
pytest tests/test_database/test_mining_cache.py::TestCreateMiningCache
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
