### PR TITLE
Remove SBioBERT dedicated class

### DIFF
--- a/data_and_models/pipelines/sentence_embedding/params.yaml
+++ b/data_and_models/pipelines/sentence_embedding/params.yaml
@@ -28,5 +28,6 @@ eval:
     init_kwargs:
       model_name_or_path: bert-base-nli-mean-tokens
   sbiobert:
-    class: SBioBERT
-    init_kwargs: {}
+    class: SentTransformer
+    init_kwargs:
+      model_name_or_path: gsarti/biobert-nli

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,8 @@ Legend
 Latest
 ======
 - |Remove| NLTK dependencies
+- |Change| Drop the dedicated :code:`SBioBERT` class, we now use
+  :code:`SentTransformer` interface to support this model.
 
 Version 0.1.0
 =============

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -298,7 +298,7 @@ def compute_database_embeddings(connection, model, indices, batch_size=10):
 
 def get_embedding_model(
     model_name_or_class: str,
-    checkpoint_path: Optional[Union[pathlib.Path, str, None]] = None,
+    checkpoint_path: Optional[Union[pathlib.Path, str]] = None,
     device: Optional[str] = "cpu",
 ) -> EmbeddingModel:
     """Load a sentence embedding model from its name or its class and checkpoint.

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -21,13 +21,12 @@ import logging
 import multiprocessing as mp
 import pathlib
 from abc import ABC, abstractmethod
+from typing import Optional, Union
 
 import joblib
 import numpy as np
 import sentence_transformers
 import sqlalchemy
-import torch
-from transformers import AutoModel, AutoTokenizer
 
 from .sql import retrieve_sentences_from_sentence_ids
 from .utils import H5
@@ -111,180 +110,6 @@ class EmbeddingModel(ABC):
             Each row is an embedding of a sentence in `preprocessed_sentences`.
         """
         return np.array([self.embed(sentence) for sentence in preprocessed_sentences])
-
-
-class SBioBERT(EmbeddingModel):
-    """Sentence BioBERT.
-
-    Parameters
-    ----------
-    device : str
-        Available device for the model. Can be {'cuda', 'cpu', None}
-
-    References
-    ----------
-    https://huggingface.co/gsarti/biobert-nli
-    """
-
-    def __init__(self, device=None):
-        available_device = device or "cpu"
-        self.device = torch.device(available_device)
-        self.sbiobert_model = AutoModel.from_pretrained("gsarti/biobert-nli").to(
-            self.device
-        )
-        self.tokenizer = AutoTokenizer.from_pretrained("gsarti/biobert-nli")
-        self.max_position_embeddings = self.sbiobert_model.config.to_dict()[
-            "max_position_embeddings"
-        ]
-
-    @property
-    def dim(self):
-        """Return dimension of the embedding."""
-        return 768
-
-    def preprocess(self, raw_sentence):
-        """Preprocess the sentence - tokenization and determining of token ids.
-
-        Note that this method already works in batched way if we pass a list.
-
-        Parameters
-        ----------
-        raw_sentence : str or list of str
-            Raw sentence to embed. One can also provide multiple sentences.
-
-        Returns
-        -------
-        encoding : transformers.BatchEncoding
-            Dictionary like object that holds the following keys: 'input_ids',
-            'token_type_ids' and 'attention_mask'. All of the corresponding
-            values are going to be ``torch.Tensor`` of shape `(n_sentences, n_tokens)`.
-
-        References
-        ----------
-        https://huggingface.co/transformers/model_doc/bert.html#transformers.BertTokenizer
-        """
-        encoding = self.tokenizer(
-            raw_sentence,
-            padding=True,
-            return_tensors="pt",
-            max_length=self.max_position_embeddings,
-            truncation=True,
-        )
-        return encoding
-
-    def preprocess_many(self, raw_sentences):
-        """Preprocess multiple sentences - tokenization and determining of token ids.
-
-        Parameters
-        ----------
-        raw_sentences : list of str
-            List of raw sentence to embed.
-
-        Returns
-        -------
-        encodings : transformers.BatchEncoding
-            Dictionary like object that holds the following keys: 'input_ids',
-            'token_type_ids' and 'attention_mask'. All of the corresponding
-            values are going to be ``torch.Tensor`` of shape `(n_sentences, n_tokens)`.
-
-        References
-        ----------
-        https://huggingface.co/transformers/model_doc/bert.html#transformers.BertTokenizer
-        """
-        return self.preprocess(raw_sentences)
-
-    def embed(self, preprocessed_sentence):
-        """Compute the sentence embedding for a given sentence.
-
-        Note that this method already works in batched way if we pass a
-        `BatchEncoding` that contains batches.
-
-        Parameters
-        ----------
-        preprocessed_sentence : transformers.BatchEncoding
-            Dictionary like object that holds the following keys: 'input_ids',
-            'token_type_ids' and 'attention_mask'. All of the corresponding
-            values are going to be ``torch.Tensor`` of shape `(n_sentences, n_tokens)`.
-
-        Returns
-        -------
-        embedding : numpy.array
-            Embedding of the specified sentence of shape (768,) if only a single
-            sample in the batch. Otherwise `(len(preprocessed_sentences), 768)`.
-
-        References
-        ----------
-        https://huggingface.co/transformers/model_doc/bert.html#transformers.BertModel
-        """
-        with torch.no_grad():
-            last_hidden_state = self.sbiobert_model(
-                **preprocessed_sentence.to(self.device)
-            )[0]
-            embedding = self.masked_mean(
-                last_hidden_state, preprocessed_sentence["attention_mask"]
-            )
-
-        return embedding.squeeze().cpu().numpy()
-
-    def embed_many(self, preprocessed_sentences):
-        """Compute the sentences embeddings for multiple sentences.
-
-        Parameters
-        ----------
-        preprocessed_sentences : transformers.BatchEncoding
-            Dictionary like object that holds the following keys: 'input_ids',
-            'token_type_ids' and 'attention_mask'. All of the corresponding
-            values are going to be ``torch.Tensor`` of shape `(n_sentences, n_tokens)`.
-
-        Returns
-        -------
-        embedding : numpy.array
-            Embedding of the specified sentence of shape
-            `(len(preprocessed_sentences), 768)`
-
-        References
-        ----------
-        https://huggingface.co/transformers/model_doc/bert.html#transformers.BertModel
-        """
-        n_samples = len(preprocessed_sentences["input_ids"])
-
-        return self.embed(preprocessed_sentences).reshape(n_samples, -1)
-
-    @staticmethod
-    def masked_mean(last_hidden_state, attention_mask):
-        """Compute the mean of token embeddings while taking into account the padding.
-
-        Note that the `sequence_length` is going to be the number of tokens of
-        the longest sentence + 2 (CLS and SEP are added).
-
-        Parameters
-        ----------
-        last_hidden_state : torch.Tensor
-            Per sample and per token embeddings as returned by the model. Shape
-            `(n_sentences, sequence_length, dim)`.
-        attention_mask : torch.Tensor
-            Boolean mask of what tokens were padded (0) or not (1). The dtype
-            is `torch.int64` and the shape is `(n_sentences, sequence_length)`.
-
-        Returns
-        -------
-        sentence_embeddings : torch.Tensor
-            Mean of token embeddings taking into account the padding. The shape
-            is `(n_sentences, dim)`.
-
-        References
-        ----------
-        https://github.com/huggingface/transformers/blob/82dd96cae74797be0c1d330566df7f929214b278/model_cards/sentence-transformers/bert-base-nli-mean-tokens/README.md
-        """
-        token_embeddings = last_hidden_state
-        input_mask_expanded = (
-            attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        )
-        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
-        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
-
-        sentence_embeddings = sum_embeddings / sum_mask
-        return sentence_embeddings
 
 
 class SentTransformer(EmbeddingModel):
@@ -471,7 +296,11 @@ def compute_database_embeddings(connection, model, indices, batch_size=10):
     return final_embeddings, retrieved_indices
 
 
-def get_embedding_model(model_name_or_class, checkpoint_path=None, device=None):
+def get_embedding_model(
+    model_name_or_class: str,
+    checkpoint_path: Optional[Union[pathlib.Path, str, None]] = None,
+    device: Optional[str] = "cpu",
+) -> EmbeddingModel:
     """Load a sentence embedding model from its name or its class and checkpoint.
 
     Usage:
@@ -492,16 +321,17 @@ def get_embedding_model(model_name_or_class, checkpoint_path=None, device=None):
 
     Parameters
     ----------
-    model_name_or_class : str
+    model_name_or_class :
         The name or class of the embedding model to load.
-    checkpoint_path : pathlib.Path or str or None
-        If 'model_name_or_class' is the class, the path of the embedding model to load.
-    device : str or None
+    checkpoint_path :
+        If 'model_name_or_class' is the class, this parameter is required and
+        it is the path of the embedding model to load.
+    device :
         The target device to which load the model ('cpu' or 'cuda').
 
     Returns
     -------
-    bluesearch.embedding_models.EmbeddingModel
+    sentence_embedding_model :
         The sentence embedding model instance.
     """
     configs = {
@@ -510,7 +340,7 @@ def get_embedding_model(model_name_or_class, checkpoint_path=None, device=None):
         "BioBERT NLI+STS": lambda: SentTransformer(
             "clagator/biobert_v1.1_pubmed_nli_sts", device
         ),
-        "SBioBERT": lambda: SBioBERT(device),
+        "SBioBERT": lambda: SentTransformer("gsarti/biobert-nli", device),
         "SBERT": lambda: SentTransformer("bert-base-nli-mean-tokens", device),
         # Scikit-learn models.
         "SklearnVectorizer": lambda: SklearnVectorizer(checkpoint_path),

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -321,17 +321,17 @@ def get_embedding_model(
 
     Parameters
     ----------
-    model_name_or_class :
+    model_name_or_class
         The name or class of the embedding model to load.
-    checkpoint_path :
+    checkpoint_path
         If 'model_name_or_class' is the class, this parameter is required and
         it is the path of the embedding model to load.
-    device :
+    device
         The target device to which load the model ('cpu' or 'cuda').
 
     Returns
     -------
-    sentence_embedding_model :
+    sentence_embedding_model : EmbeddingModel
         The sentence embedding model instance.
     """
     configs = {

--- a/src/bluesearch/entrypoint/embedding_server.py
+++ b/src/bluesearch/entrypoint/embedding_server.py
@@ -43,7 +43,7 @@ def get_embedding_app():
 
     # Load embedding models
     logger.info("Loading embedding models")
-    supported_models = ["SBERT", "SBioBERT", "BIOBERT NLI+STS"]
+    supported_models = ["SBERT", "SBioBERT", "BioBERT NLI+STS"]
     embedding_models = {
         model_name: get_embedding_model(model_name) for model_name in supported_models
     }

--- a/src/bluesearch/entrypoint/embedding_server.py
+++ b/src/bluesearch/entrypoint/embedding_server.py
@@ -20,12 +20,12 @@
 import logging
 import sys
 
+from ..embedding_models import get_embedding_model
 from ._helper import configure_logging, get_var, run_server
 
 
 def get_embedding_app():
     """Construct the embedding flask app."""
-    from ..embedding_models import SBioBERT, SentTransformer
     from ..server.embedding_server import EmbeddingServer
 
     # Read configuration
@@ -43,10 +43,9 @@ def get_embedding_app():
 
     # Load embedding models
     logger.info("Loading embedding models")
+    supported_models = ["SBERT", "SBioBERT", "BIOBERT NLI+STS"]
     embedding_models = {
-        "SBERT": SentTransformer("bert-base-nli-mean-tokens"),
-        "BIOBERT NLI+STS": SentTransformer("clagator/biobert_v1.1_pubmed_nli_sts"),
-        "SBioBERT": SBioBERT(),
+        model_name: get_embedding_model(model_name) for model_name in supported_models
     }
 
     # Create Server app

--- a/src/bluesearch/server/embedding_server.py
+++ b/src/bluesearch/server/embedding_server.py
@@ -106,7 +106,7 @@ class EmbeddingServer(Flask):
                     "description": "Compute text embeddings.",
                     "response_content_type": "application/json",
                     "required_fields": {
-                        "model": ["SBioBERT", "SBERT"],
+                        "model": ["SBioBERT", "SBERT", "BIOBERT NLI+STS"],
                         "text": [],
                     },
                 },

--- a/src/bluesearch/server/embedding_server.py
+++ b/src/bluesearch/server/embedding_server.py
@@ -106,7 +106,7 @@ class EmbeddingServer(Flask):
                     "description": "Compute text embeddings.",
                     "response_content_type": "application/json",
                     "required_fields": {
-                        "model": ["SBioBERT", "SBERT", "BIOBERT NLI+STS"],
+                        "model": ["SBioBERT", "SBERT", "BioBERT NLI+STS"],
                         "text": [],
                     },
                 },

--- a/src/bluesearch/server/search_server.py
+++ b/src/bluesearch/server/search_server.py
@@ -24,7 +24,7 @@ from flask import Flask, jsonify, request
 
 import bluesearch
 
-from ..embedding_models import SBioBERT, SentTransformer
+from ..embedding_models import EmbeddingModel, get_embedding_model
 from ..search import SearchEngine
 from ..utils import H5
 
@@ -110,18 +110,18 @@ class SearchServer(Flask):
 
         self.logger.info("Initialization done.")
 
-    def _get_model(self, model_name):
+    def _get_model(self, model_name: str) -> EmbeddingModel:
         """Construct an embedding model from its name.
 
         Parameters
         ----------
-        model_name : str
+        model_name :
             The name of the model.
 
         Returns
         -------
-        bluesearch.embedding_models.EmbeddingModel
-            The embedding model class.
+        sentence_embedding_model :
+            The sentence embedding model instance.
         """
         biobert_nli_sts_cord19_v1_model_name = "biobert_nli_sts_cord19_v1"
         biobert_nli_sts_cord19_v1_model_path = (
@@ -129,13 +129,11 @@ class SearchServer(Flask):
         )
 
         model_factories = {
-            "SBioBERT": lambda: SBioBERT(),
-            "SBERT": lambda: SentTransformer("bert-base-nli-mean-tokens"),
-            "BIOBERT NLI+STS": lambda: SentTransformer(
-                "clagator/biobert_v1.1_pubmed_nli_sts"
-            ),
-            "BioBERT NLI+STS CORD-19 v1": lambda: SentTransformer(
-                biobert_nli_sts_cord19_v1_model_path
+            "SBioBERT": lambda: get_embedding_model("SBioBERT"),
+            "SBERT": lambda: get_embedding_model("SBERT"),
+            "BioBERT NLI+STS": lambda: get_embedding_model("BioBERT NLI+STS"),
+            "BioBERT NLI+STS CORD-19 v1": lambda: get_embedding_model(
+                "SentTransformer", checkpoint_path=biobert_nli_sts_cord19_v1_model_path
             ),
         }
 

--- a/src/bluesearch/server/search_server.py
+++ b/src/bluesearch/server/search_server.py
@@ -120,7 +120,7 @@ class SearchServer(Flask):
 
         Returns
         -------
-        sentence_embedding_model :
+        sentence_embedding_model : EmbeddingModel
             The sentence embedding model instance.
         """
         biobert_nli_sts_cord19_v1_model_name = "biobert_nli_sts_cord19_v1"

--- a/tests/test_entrypoint/test_embedding_server.py
+++ b/tests/test_entrypoint/test_embedding_server.py
@@ -38,7 +38,7 @@ def test_environment_reading(monkeypatch, tmpdir):
     )
 
     # Mock all of our embedding models
-    embedding_models = ["SBioBERT", "SentTransformer"]
+    embedding_models = ["SentTransformer"]
 
     for model in embedding_models:
         monkeypatch.setattr(f"bluesearch.embedding_models.{model}", Mock())

--- a/tests/test_server/test_search_server.py
+++ b/tests/test_server/test_search_server.py
@@ -33,15 +33,14 @@ def search_client(
     """Fixture to create a client for mining_server."""
 
     sbiobert_model_inst = Mock()
-    sbiobert_model_class = Mock()
-    sbiobert_model_class.return_value = sbiobert_model_inst
     sbiobert_model_inst.preprocess.return_value = "hello"
     sbiobert_model_inst.embed.return_value = np.ones(
         (test_parameters["embedding_size"],)
     )
 
     monkeypatch.setattr(
-        "bluesearch.server.search_server.SBioBERT", sbiobert_model_class
+        "bluesearch.server.search_server.get_embedding_model",
+        lambda *args, **kwargs: sbiobert_model_inst,
     )
 
     indices = H5.find_populated_rows(embeddings_h5_path, "SBioBERT")

--- a/tests/test_server/test_search_server.py
+++ b/tests/test_server/test_search_server.py
@@ -32,15 +32,15 @@ def search_client(
 ):
     """Fixture to create a client for mining_server."""
 
-    sbiobert_model_inst = Mock()
-    sbiobert_model_inst.preprocess.return_value = "hello"
-    sbiobert_model_inst.embed.return_value = np.ones(
+    fake_embedding_model = Mock()
+    fake_embedding_model.preprocess.return_value = "hello"
+    fake_embedding_model.embed.return_value = np.ones(
         (test_parameters["embedding_size"],)
     )
 
     monkeypatch.setattr(
         "bluesearch.server.search_server.get_embedding_model",
-        lambda *args, **kwargs: sbiobert_model_inst,
+        lambda *args, **kwargs: fake_embedding_model,
     )
 
     indices = H5.find_populated_rows(embeddings_h5_path, "SBioBERT")


### PR DESCRIPTION
Fixes #275 .

## Description

Previously we were using a dedicated class for SBioBERT, where in particular we defined a method for the mean pooling with attention mask prescribed [here](https://huggingface.co/sentence-transformers/bert-base-nli-mean-tokens).

This PR reduces the complexity of that solution by leveraging [`UKPLab/sentence-transformers`](https://github.com/UKPLab/sentence-transformers/) and the pretrained model [`gsarti/biobert-nli`](https://huggingface.co/gsarti/biobert-nli) through the interface provided by our `bluesearch.embedding_models.SentTransformers`.

## How to test?

The embeddings produced using `SBioBERT` did not change. You can try to run
```python
from bluesearch.embedding_models import get_embedding_model
sbiobert = get_embedding_model("SBioBERT")
sentences = [  # put whatever you want here
     "The neuron is the basic working unit of the brain.", 
     "A system of cells interlinked within one stem."
]  
preprocessed = sbiobert.preprocess_many(sentences)
embedded = sbiobert.embed_many(preprocessed)
```
using the code on `master` and on `remove_sbiobert_class` (e.g. using `pip install -e .` + `git checkout <branch_name>`).

You will see that the arrays `embedded` are the same. **Note**: preprocessed will not be the same because `sentence-transformers` don't need any extra manual pre-processing and therefore its `preprocess()` method is the identity.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 