### PR TITLE
Upgrade to dvc>=2  + release bluesearch v0.1.1

### DIFF
--- a/data_and_models/pipelines/ner/Dockerfile
+++ b/data_and_models/pipelines/ner/Dockerfile
@@ -35,7 +35,7 @@ COPY prodigy-1.10.7-cp36.cp37.cp38-cp36m.cp37m.cp38-linux_x86_64.whl /bbs/tmp
 RUN pip install /bbs/tmp/prodigy-1.10.7-cp36.cp37.cp38-cp36m.cp37m.cp38-linux_x86_64.whl
 
 # Instal BlueBrainSearach -- revision can be a branch, sha, or tag
-ARG BBS_REVISION=v0.1.0
+ARG BBS_REVISION=v0.1.1
 ADD . /src
 WORKDIR /src
 RUN git checkout $BBS_REVISION

--- a/data_and_models/pipelines/ner/dvc.lock
+++ b/data_and_models/pipelines/ner/dvc.lock
@@ -1,572 +1,578 @@
-train_model1:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-    --output_dir ../../models/ner/model1 --model_name model1
-  deps:
-  - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-    md5: 613308ed830d86284a1aee2747d911d0
-    size: 324136
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model1:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_bc5cdr_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model1
-    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-train_model2:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-    --output_dir ../../models/ner/model2 --model_name model2
-  deps:
-  - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-    md5: 2459e49418599ff96ab9db60a29b757b
-    size: 953728
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model2:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_bionlp13cg_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model2
-    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-train_model3:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-    --output_dir ../../models/ner/model3 --model_name model3
-  deps:
-  - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-    md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
-    size: 969928
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model3:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_craft_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model3
-    md5: 1e6e071c4a730f49f671155e2c6065db.dir
-train_model4:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-    --output_dir ../../models/ner/model4 --model_name model4
-  deps:
-  - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-    md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
-    size: 267307
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model4:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_jnlpba_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model4
-    md5: 60213648fac010c178b81983ff76492b.dir
-train_model5:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-    --output_dir ../../models/ner/model5 --model_name model5
-  deps:
-  - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-    md5: ceb6ea77d2a6a69962b88218f4f5a663
-    size: 394725
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model5:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_craft_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model5
-    md5: aab9909077d22a91c01042bf7468e80d.dir
-eval_disease:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
-    --etype DISEASE
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-    size: 100183520
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.DISEASE:
-        etype_name: DISEASE
-  outs:
-  - path: ../../metrics/ner/disease.json
-    md5: 034f6a3ffaabe1fdb4c0900b1c719fac
-    size: 273
-eval_cell_compartment:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
-    --etype CELL_COMPARTMENT
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CELL_COMPARTMENT:
-        etype_name: CELLULAR_COMPONENT
-  outs:
-  - path: ../../metrics/ner/cell_compartment.json
-    md5: 0dc8d0f92415d14edfa7cdc8e5381c65
-    size: 260
-eval_drug:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json --etype
-    DRUG
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.DRUG:
-        etype_name: SIMPLE_CHEMICAL
-  outs:
-  - path: ../../metrics/ner/drug.json
-    md5: 27d7edd2cf470318fcf8be22f3610c0c
-eval_organ:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
-    --etype ORGAN
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.ORGAN:
-        etype_name: ORGAN
-  outs:
-  - path: ../../metrics/ner/organ.json
-    md5: 55df17bf18a84a6ef670ae8b2e80af73
-    size: 275
-eval_chemical:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
-    --etype CHEMICAL
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CHEMICAL:
-        etype_name: CHEBI
-  outs:
-  - path: ../../metrics/ner/chemical.json
-    md5: c88b746d0d3dbb0a2b1444c3ab64420c
-eval_organism:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
-    --etype ORGANISM
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.ORGANISM:
-        etype_name: TAXON
-  outs:
-  - path: ../../metrics/ner/organism.json
-    md5: cb2fbe378ad643be3ab2d01b7350e591
-eval_cell_type:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
-    --etype CELL_TYPE
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CELL_TYPE:
-        etype_name: CELL_TYPE
-  outs:
-  - path: ../../metrics/ner/cell_type.json
-    md5: 690a1b81737164cfed2553c9e6852ca2
-    size: 272
-eval_protein:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
-    --etype PROTEIN
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.PROTEIN:
-        etype_name: PROTEIN
-  outs:
-  - path: ../../metrics/ner/protein.json
-    md5: 5c0de70df94fddcbadbb1206e257efc8
-    size: 263
-eval_pathway:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
-    --etype PATHWAY
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model5
-    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-    size: 100224717
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.PATHWAY:
-        etype_name: PATHWAY
-  outs:
-  - path: ../../metrics/ner/pathway.json
-    md5: 372df4c2666d0d12215d4189216fa783
-add_er_1:
-  cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
-    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model1
-    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-    size: 100181750
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.DISEASE:
-        etype_name: DISEASE
-  outs:
-  - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-    size: 100183520
-    nfiles: 18
-add_er_2:
-  cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model2
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model2
-    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-    size: 100192674
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CELL_COMPARTMENT:
-        etype_name: CELLULAR_COMPONENT
-      eval.DRUG:
-        etype_name: SIMPLE_CHEMICAL
-      eval.ORGAN:
-        etype_name: ORGAN
-  outs:
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-add_er_3:
-  cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model3
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model3
-    md5: 1e6e071c4a730f49f671155e2c6065db.dir
-    size: 100227109
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CHEMICAL:
-        etype_name: CHEBI
-      eval.ORGANISM:
-        etype_name: TAXON
-  outs:
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-add_er_4:
-  cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model4
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model4
-    md5: 60213648fac010c178b81983ff76492b.dir
-    size: 100214049
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CELL_TYPE:
-        etype_name: CELL_TYPE
-      eval.PROTEIN:
-        etype_name: PROTEIN
-  outs:
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-add_er_5:
-  cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
-    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model5
-    md5: aab9909077d22a91c01042bf7468e80d.dir
-    size: 100222954
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.PATHWAY:
-        etype_name: PATHWAY
-  outs:
-  - path: ../../models/ner_er/model5
-    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-    size: 100224717
-    nfiles: 18
-interrater:
-  cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-    --output_dir ../../metrics/ner/interrater/
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
-    md5: 735cba4532a4c2c5e928399eafc1000f
-    size: 806212
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-    md5: 6e248863604ce14861f38e7c9a8281bb
-    size: 64285
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: interrater.py
-    md5: dd9cabff57a4608753e0777838f9c746
-    size: 2984
-  outs:
-  - path: ../../metrics/ner/interrater/cell_compartment.json
-    md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
-    size: 246
-  - path: ../../metrics/ner/interrater/cell_type.json
-    md5: 5da8476adaad46fd5236dc9da81e8624
-    size: 273
-  - path: ../../metrics/ner/interrater/chemical.json
-    md5: 9842e0e07063f735ecff0bc082999b18
-    size: 260
-  - path: ../../metrics/ner/interrater/condition.json
-    md5: 23eb361695b6b80ccd3e9137a52725c4
-    size: 274
-  - path: ../../metrics/ner/interrater/disease.json
-    md5: 110df2aa12b86f04c19656a43cea8bd2
-    size: 274
-  - path: ../../metrics/ner/interrater/drug.json
-    md5: f58359194658db2bb26483eaf0b931dc
-    size: 260
-  - path: ../../metrics/ner/interrater/organ.json
-    md5: 6652f267bbcc37cd9ac4a9c934085aae
-    size: 261
-  - path: ../../metrics/ner/interrater/organism.json
-    md5: 6e74ba7077e2a999ed6dc598ee78419d
-    size: 274
-  - path: ../../metrics/ner/interrater/pathway.json
-    md5: e038e353873bb5e222e28d6b66d78ee9
-    size: 274
-  - path: ../../metrics/ner/interrater/protein.json
-    md5: 7c7aaf345cba6d103ccf690da0e2f898
-    size: 274
+schema: '2.0'
+stages:
+  train_model1:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+      --output_dir ../../models/ner/model1 --model_name model1
+    deps:
+    - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+      md5: 613308ed830d86284a1aee2747d911d0
+      size: 324136
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model1:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_bc5cdr_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model1
+      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+  train_model2:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+      --output_dir ../../models/ner/model2 --model_name model2
+    deps:
+    - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+      md5: 2459e49418599ff96ab9db60a29b757b
+      size: 953728
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model2:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_bionlp13cg_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model2
+      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+  train_model3:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+      --output_dir ../../models/ner/model3 --model_name model3
+    deps:
+    - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+      md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
+      size: 969928
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model3:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_craft_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model3
+      md5: 1e6e071c4a730f49f671155e2c6065db.dir
+  train_model4:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+      --output_dir ../../models/ner/model4 --model_name model4
+    deps:
+    - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+      md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
+      size: 267307
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model4:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_jnlpba_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model4
+      md5: 60213648fac010c178b81983ff76492b.dir
+  train_model5:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+      --output_dir ../../models/ner/model5 --model_name model5
+    deps:
+    - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+      md5: ceb6ea77d2a6a69962b88218f4f5a663
+      size: 394725
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model5:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_craft_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model5
+      md5: aab9909077d22a91c01042bf7468e80d.dir
+  eval_disease:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
+      --etype DISEASE
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model1
+      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+      size: 100183520
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.DISEASE:
+          etype_name: DISEASE
+    outs:
+    - path: ../../metrics/ner/disease.json
+      md5: 034f6a3ffaabe1fdb4c0900b1c719fac
+      size: 273
+  eval_cell_compartment:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
+      --etype CELL_COMPARTMENT
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CELL_COMPARTMENT:
+          etype_name: CELLULAR_COMPONENT
+    outs:
+    - path: ../../metrics/ner/cell_compartment.json
+      md5: 0dc8d0f92415d14edfa7cdc8e5381c65
+      size: 260
+  eval_drug:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json
+      --etype DRUG
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.DRUG:
+          etype_name: SIMPLE_CHEMICAL
+    outs:
+    - path: ../../metrics/ner/drug.json
+      md5: 27d7edd2cf470318fcf8be22f3610c0c
+      size: 272
+  eval_organ:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
+      --etype ORGAN
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.ORGAN:
+          etype_name: ORGAN
+    outs:
+    - path: ../../metrics/ner/organ.json
+      md5: 55df17bf18a84a6ef670ae8b2e80af73
+      size: 275
+  eval_chemical:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
+      --etype CHEMICAL
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CHEMICAL:
+          etype_name: CHEBI
+    outs:
+    - path: ../../metrics/ner/chemical.json
+      md5: c88b746d0d3dbb0a2b1444c3ab64420c
+      size: 259
+  eval_organism:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
+      --etype ORGANISM
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.ORGANISM:
+          etype_name: TAXON
+    outs:
+    - path: ../../metrics/ner/organism.json
+      md5: cb2fbe378ad643be3ab2d01b7350e591
+      size: 275
+  eval_cell_type:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
+      --etype CELL_TYPE
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CELL_TYPE:
+          etype_name: CELL_TYPE
+    outs:
+    - path: ../../metrics/ner/cell_type.json
+      md5: 690a1b81737164cfed2553c9e6852ca2
+      size: 272
+  eval_protein:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
+      --etype PROTEIN
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.PROTEIN:
+          etype_name: PROTEIN
+    outs:
+    - path: ../../metrics/ner/protein.json
+      md5: 5c0de70df94fddcbadbb1206e257efc8
+      size: 263
+  eval_pathway:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
+      --etype PATHWAY
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model5
+      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+      size: 100224717
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.PATHWAY:
+          etype_name: PATHWAY
+    outs:
+    - path: ../../metrics/ner/pathway.json
+      md5: 372df4c2666d0d12215d4189216fa783
+      size: 274
+  add_er_1:
+    cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
+      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model1
+      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+      size: 100181750
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.DISEASE:
+          etype_name: DISEASE
+    outs:
+    - path: ../../models/ner_er/model1
+      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+      size: 100183520
+      nfiles: 18
+  add_er_2:
+    cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model2
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model2
+      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+      size: 100192674
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CELL_COMPARTMENT:
+          etype_name: CELLULAR_COMPONENT
+        eval.DRUG:
+          etype_name: SIMPLE_CHEMICAL
+        eval.ORGAN:
+          etype_name: ORGAN
+    outs:
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+  add_er_3:
+    cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model3
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model3
+      md5: 1e6e071c4a730f49f671155e2c6065db.dir
+      size: 100227109
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CHEMICAL:
+          etype_name: CHEBI
+        eval.ORGANISM:
+          etype_name: TAXON
+    outs:
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+  add_er_4:
+    cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model4
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model4
+      md5: 60213648fac010c178b81983ff76492b.dir
+      size: 100214049
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CELL_TYPE:
+          etype_name: CELL_TYPE
+        eval.PROTEIN:
+          etype_name: PROTEIN
+    outs:
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+  add_er_5:
+    cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
+      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model5
+      md5: aab9909077d22a91c01042bf7468e80d.dir
+      size: 100222954
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.PATHWAY:
+          etype_name: PATHWAY
+    outs:
+    - path: ../../models/ner_er/model5
+      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+      size: 100224717
+      nfiles: 18
+  interrater:
+    cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+      --output_dir ../../metrics/ner/interrater/
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
+      md5: 735cba4532a4c2c5e928399eafc1000f
+      size: 806212
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+      md5: 6e248863604ce14861f38e7c9a8281bb
+      size: 64285
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: interrater.py
+      md5: dd9cabff57a4608753e0777838f9c746
+      size: 2984
+    outs:
+    - path: ../../metrics/ner/interrater/cell_compartment.json
+      md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
+      size: 246
+    - path: ../../metrics/ner/interrater/cell_type.json
+      md5: 5da8476adaad46fd5236dc9da81e8624
+      size: 273
+    - path: ../../metrics/ner/interrater/chemical.json
+      md5: 9842e0e07063f735ecff0bc082999b18
+      size: 260
+    - path: ../../metrics/ner/interrater/condition.json
+      md5: 23eb361695b6b80ccd3e9137a52725c4
+      size: 274
+    - path: ../../metrics/ner/interrater/disease.json
+      md5: 110df2aa12b86f04c19656a43cea8bd2
+      size: 274
+    - path: ../../metrics/ner/interrater/drug.json
+      md5: f58359194658db2bb26483eaf0b931dc
+      size: 260
+    - path: ../../metrics/ner/interrater/organ.json
+      md5: 6652f267bbcc37cd9ac4a9c934085aae
+      size: 261
+    - path: ../../metrics/ner/interrater/organism.json
+      md5: 6e74ba7077e2a999ed6dc598ee78419d
+      size: 274
+    - path: ../../metrics/ner/interrater/pathway.json
+      md5: e038e353873bb5e222e28d6b66d78ee9
+      size: 274
+    - path: ../../metrics/ner/interrater/protein.json
+      md5: 7c7aaf345cba6d103ccf690da0e2f898
+      size: 274

--- a/data_and_models/pipelines/ner/dvc.lock
+++ b/data_and_models/pipelines/ner/dvc.lock
@@ -1,572 +1,574 @@
-train_model1:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-    --output_dir ../../models/ner/model1 --model_name model1
-  deps:
-  - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-    md5: 613308ed830d86284a1aee2747d911d0
-    size: 324136
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model1:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_bc5cdr_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model1
-    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-train_model2:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-    --output_dir ../../models/ner/model2 --model_name model2
-  deps:
-  - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-    md5: 2459e49418599ff96ab9db60a29b757b
-    size: 953728
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model2:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_bionlp13cg_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model2
-    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-train_model3:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-    --output_dir ../../models/ner/model3 --model_name model3
-  deps:
-  - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-    md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
-    size: 969928
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model3:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_craft_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model3
-    md5: 1e6e071c4a730f49f671155e2c6065db.dir
-train_model4:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-    --output_dir ../../models/ner/model4 --model_name model4
-  deps:
-  - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-    md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
-    size: 267307
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model4:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_jnlpba_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model4
-    md5: 60213648fac010c178b81983ff76492b.dir
-train_model5:
-  cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-    --output_dir ../../models/ner/model5 --model_name model5
-  deps:
-  - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-    md5: ceb6ea77d2a6a69962b88218f4f5a663
-    size: 394725
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: train.py
-    md5: 1ccae6b57456b9e5790a0f1232880f4b
-    size: 2505
-  params:
-    params.yaml:
-      train.model5:
-        prodigy_train_kwargs:
-          spacy_model: en_ner_craft_md
-          eval_split: 0.1
-          n_iter: 10
-          dropout: 0.2
-  outs:
-  - path: ../../models/ner/model5
-    md5: aab9909077d22a91c01042bf7468e80d.dir
-eval_disease:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
-    --etype DISEASE
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-    size: 100183520
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.DISEASE:
-        etype_name: DISEASE
-  outs:
-  - path: ../../metrics/ner/disease.json
-    md5: 034f6a3ffaabe1fdb4c0900b1c719fac
-    size: 273
-eval_cell_compartment:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
-    --etype CELL_COMPARTMENT
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CELL_COMPARTMENT:
-        etype_name: CELLULAR_COMPONENT
-  outs:
-  - path: ../../metrics/ner/cell_compartment.json
-    md5: 0dc8d0f92415d14edfa7cdc8e5381c65
-    size: 260
-eval_drug:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json --etype
-    DRUG
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.DRUG:
-        etype_name: SIMPLE_CHEMICAL
-  outs:
-  - path: ../../metrics/ner/drug.json
-    md5: 27d7edd2cf470318fcf8be22f3610c0c
-eval_organ:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
-    --etype ORGAN
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.ORGAN:
-        etype_name: ORGAN
-  outs:
-  - path: ../../metrics/ner/organ.json
-    md5: 55df17bf18a84a6ef670ae8b2e80af73
-    size: 275
-eval_chemical:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
-    --etype CHEMICAL
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CHEMICAL:
-        etype_name: CHEBI
-  outs:
-  - path: ../../metrics/ner/chemical.json
-    md5: c88b746d0d3dbb0a2b1444c3ab64420c
-eval_organism:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
-    --etype ORGANISM
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.ORGANISM:
-        etype_name: TAXON
-  outs:
-  - path: ../../metrics/ner/organism.json
-    md5: cb2fbe378ad643be3ab2d01b7350e591
-eval_cell_type:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
-    --etype CELL_TYPE
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.CELL_TYPE:
-        etype_name: CELL_TYPE
-  outs:
-  - path: ../../metrics/ner/cell_type.json
-    md5: 690a1b81737164cfed2553c9e6852ca2
-    size: 272
-eval_protein:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
-    --etype PROTEIN
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.PROTEIN:
-        etype_name: PROTEIN
-  outs:
-  - path: ../../metrics/ner/protein.json
-    md5: 5c0de70df94fddcbadbb1206e257efc8
-    size: 263
-eval_pathway:
-  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
-    --etype PATHWAY
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../models/ner_er/model5
-    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-    size: 100224717
-    nfiles: 18
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: eval.py
-    md5: 3c9e86f7cbfaea90929e96a6443a16d4
-    size: 3391
-  params:
-    params.yaml:
-      eval.PATHWAY:
-        etype_name: PATHWAY
-  outs:
-  - path: ../../metrics/ner/pathway.json
-    md5: 372df4c2666d0d12215d4189216fa783
-add_er_1:
-  cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
-    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model1
-    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-    size: 100181750
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.DISEASE:
-        etype_name: DISEASE
-  outs:
-  - path: ../../models/ner_er/model1
-    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-    size: 100183520
-    nfiles: 18
-add_er_2:
-  cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model2
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model2
-    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-    size: 100192674
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CELL_COMPARTMENT:
-        etype_name: CELLULAR_COMPONENT
-      eval.DRUG:
-        etype_name: SIMPLE_CHEMICAL
-      eval.ORGAN:
-        etype_name: ORGAN
-  outs:
-  - path: ../../models/ner_er/model2
-    md5: bf09a6293528ff512e97e8eca8420f33.dir
-    size: 100194437
-    nfiles: 18
-add_er_3:
-  cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model3
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model3
-    md5: 1e6e071c4a730f49f671155e2c6065db.dir
-    size: 100227109
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CHEMICAL:
-        etype_name: CHEBI
-      eval.ORGANISM:
-        etype_name: TAXON
-  outs:
-  - path: ../../models/ner_er/model3
-    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-    size: 100228858
-    nfiles: 18
-add_er_4:
-  cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
-    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-    ../../models/ner_er/model4
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model4
-    md5: 60213648fac010c178b81983ff76492b.dir
-    size: 100214049
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.CELL_TYPE:
-        etype_name: CELL_TYPE
-      eval.PROTEIN:
-        etype_name: PROTEIN
-  outs:
-  - path: ../../models/ner_er/model4
-    md5: 00b992b7a23d903e5a090657dc6af453.dir
-    size: 100215798
-    nfiles: 18
-add_er_5:
-  cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
-    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
-  deps:
-  - path: ../../annotations/ner/rule_based_patterns.jsonl
-    md5: 044c1a326c2472aa4eb72c4c98a7400b
-    size: 1709
-  - path: ../../models/ner/model5
-    md5: aab9909077d22a91c01042bf7468e80d.dir
-    size: 100222954
-    nfiles: 16
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: add_er.py
-    md5: aafbf109663670ded44f84025e4a37a3
-    size: 2531
-  params:
-    params.yaml:
-      eval.PATHWAY:
-        etype_name: PATHWAY
-  outs:
-  - path: ../../models/ner_er/model5
-    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-    size: 100224717
-    nfiles: 18
-interrater:
-  cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-    --output_dir ../../metrics/ner/interrater/
-  deps:
-  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-    md5: 563441b77b5c39063cda3fa0fb03803c
-    size: 883041
-  - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
-    md5: 735cba4532a4c2c5e928399eafc1000f
-    size: 806212
-  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-    md5: 117da032ef2e2792429dff88c06c90b7
-    size: 62653
-  - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-    md5: 6e248863604ce14861f38e7c9a8281bb
-    size: 64285
-  - path: Dockerfile
-    md5: da73fa137594c015a32f36ebc772f553
-    size: 1987
-  - path: interrater.py
-    md5: dd9cabff57a4608753e0777838f9c746
-    size: 2984
-  outs:
-  - path: ../../metrics/ner/interrater/cell_compartment.json
-    md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
-    size: 246
-  - path: ../../metrics/ner/interrater/cell_type.json
-    md5: 5da8476adaad46fd5236dc9da81e8624
-    size: 273
-  - path: ../../metrics/ner/interrater/chemical.json
-    md5: 9842e0e07063f735ecff0bc082999b18
-    size: 260
-  - path: ../../metrics/ner/interrater/condition.json
-    md5: 23eb361695b6b80ccd3e9137a52725c4
-    size: 274
-  - path: ../../metrics/ner/interrater/disease.json
-    md5: 110df2aa12b86f04c19656a43cea8bd2
-    size: 274
-  - path: ../../metrics/ner/interrater/drug.json
-    md5: f58359194658db2bb26483eaf0b931dc
-    size: 260
-  - path: ../../metrics/ner/interrater/organ.json
-    md5: 6652f267bbcc37cd9ac4a9c934085aae
-    size: 261
-  - path: ../../metrics/ner/interrater/organism.json
-    md5: 6e74ba7077e2a999ed6dc598ee78419d
-    size: 274
-  - path: ../../metrics/ner/interrater/pathway.json
-    md5: e038e353873bb5e222e28d6b66d78ee9
-    size: 274
-  - path: ../../metrics/ner/interrater/protein.json
-    md5: 7c7aaf345cba6d103ccf690da0e2f898
-    size: 274
+schema: '2.0'
+stages:
+  train_model1:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+      --output_dir ../../models/ner/model1 --model_name model1
+    deps:
+    - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+      md5: 613308ed830d86284a1aee2747d911d0
+      size: 324136
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model1:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_bc5cdr_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model1
+      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+  train_model2:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+      --output_dir ../../models/ner/model2 --model_name model2
+    deps:
+    - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+      md5: 2459e49418599ff96ab9db60a29b757b
+      size: 953728
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model2:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_bionlp13cg_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model2
+      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+  train_model3:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+      --output_dir ../../models/ner/model3 --model_name model3
+    deps:
+    - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+      md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
+      size: 969928
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model3:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_craft_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model3
+      md5: 1e6e071c4a730f49f671155e2c6065db.dir
+  train_model4:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+      --output_dir ../../models/ner/model4 --model_name model4
+    deps:
+    - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+      md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
+      size: 267307
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model4:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_jnlpba_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model4
+      md5: 60213648fac010c178b81983ff76492b.dir
+  train_model5:
+    cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+      --output_dir ../../models/ner/model5 --model_name model5
+    deps:
+    - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+      md5: ceb6ea77d2a6a69962b88218f4f5a663
+      size: 394725
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: train.py
+      md5: 1ccae6b57456b9e5790a0f1232880f4b
+      size: 2505
+    params:
+      params.yaml:
+        train.model5:
+          prodigy_train_kwargs:
+            spacy_model: en_ner_craft_md
+            eval_split: 0.1
+            n_iter: 10
+            dropout: 0.2
+    outs:
+    - path: ../../models/ner/model5
+      md5: aab9909077d22a91c01042bf7468e80d.dir
+  eval_disease:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
+      --etype DISEASE
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model1
+      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+      size: 100183520
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.DISEASE:
+          etype_name: DISEASE
+    outs:
+    - path: ../../metrics/ner/disease.json
+      md5: 034f6a3ffaabe1fdb4c0900b1c719fac
+      size: 273
+  eval_cell_compartment:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
+      --etype CELL_COMPARTMENT
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CELL_COMPARTMENT:
+          etype_name: CELLULAR_COMPONENT
+    outs:
+    - path: ../../metrics/ner/cell_compartment.json
+      md5: 0dc8d0f92415d14edfa7cdc8e5381c65
+      size: 260
+  eval_drug:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json
+      --etype DRUG
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.DRUG:
+          etype_name: SIMPLE_CHEMICAL
+    outs:
+    - path: ../../metrics/ner/drug.json
+      md5: 27d7edd2cf470318fcf8be22f3610c0c
+  eval_organ:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
+      --etype ORGAN
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.ORGAN:
+          etype_name: ORGAN
+    outs:
+    - path: ../../metrics/ner/organ.json
+      md5: 55df17bf18a84a6ef670ae8b2e80af73
+      size: 275
+  eval_chemical:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
+      --etype CHEMICAL
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CHEMICAL:
+          etype_name: CHEBI
+    outs:
+    - path: ../../metrics/ner/chemical.json
+      md5: c88b746d0d3dbb0a2b1444c3ab64420c
+  eval_organism:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
+      --etype ORGANISM
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.ORGANISM:
+          etype_name: TAXON
+    outs:
+    - path: ../../metrics/ner/organism.json
+      md5: cb2fbe378ad643be3ab2d01b7350e591
+  eval_cell_type:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
+      --etype CELL_TYPE
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.CELL_TYPE:
+          etype_name: CELL_TYPE
+    outs:
+    - path: ../../metrics/ner/cell_type.json
+      md5: 690a1b81737164cfed2553c9e6852ca2
+      size: 272
+  eval_protein:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
+      --etype PROTEIN
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.PROTEIN:
+          etype_name: PROTEIN
+    outs:
+    - path: ../../metrics/ner/protein.json
+      md5: 5c0de70df94fddcbadbb1206e257efc8
+      size: 263
+  eval_pathway:
+    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
+      --etype PATHWAY
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../models/ner_er/model5
+      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+      size: 100224717
+      nfiles: 18
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: eval.py
+      md5: 3c9e86f7cbfaea90929e96a6443a16d4
+      size: 3391
+    params:
+      params.yaml:
+        eval.PATHWAY:
+          etype_name: PATHWAY
+    outs:
+    - path: ../../metrics/ner/pathway.json
+      md5: 372df4c2666d0d12215d4189216fa783
+  add_er_1:
+    cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
+      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model1
+      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+      size: 100181750
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.DISEASE:
+          etype_name: DISEASE
+    outs:
+    - path: ../../models/ner_er/model1
+      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+      size: 100183520
+      nfiles: 18
+  add_er_2:
+    cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model2
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model2
+      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+      size: 100192674
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CELL_COMPARTMENT:
+          etype_name: CELLULAR_COMPONENT
+        eval.DRUG:
+          etype_name: SIMPLE_CHEMICAL
+        eval.ORGAN:
+          etype_name: ORGAN
+    outs:
+    - path: ../../models/ner_er/model2
+      md5: bf09a6293528ff512e97e8eca8420f33.dir
+      size: 100194437
+      nfiles: 18
+  add_er_3:
+    cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model3
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model3
+      md5: 1e6e071c4a730f49f671155e2c6065db.dir
+      size: 100227109
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CHEMICAL:
+          etype_name: CHEBI
+        eval.ORGANISM:
+          etype_name: TAXON
+    outs:
+    - path: ../../models/ner_er/model3
+      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+      size: 100228858
+      nfiles: 18
+  add_er_4:
+    cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
+      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+      ../../models/ner_er/model4
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model4
+      md5: 60213648fac010c178b81983ff76492b.dir
+      size: 100214049
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.CELL_TYPE:
+          etype_name: CELL_TYPE
+        eval.PROTEIN:
+          etype_name: PROTEIN
+    outs:
+    - path: ../../models/ner_er/model4
+      md5: 00b992b7a23d903e5a090657dc6af453.dir
+      size: 100215798
+      nfiles: 18
+  add_er_5:
+    cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
+      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
+    deps:
+    - path: ../../annotations/ner/rule_based_patterns.jsonl
+      md5: 044c1a326c2472aa4eb72c4c98a7400b
+      size: 1709
+    - path: ../../models/ner/model5
+      md5: aab9909077d22a91c01042bf7468e80d.dir
+      size: 100222954
+      nfiles: 16
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: add_er.py
+      md5: dc7fbe1d2370f056eef99dad7c9da011
+      size: 2833
+    params:
+      params.yaml:
+        eval.PATHWAY:
+          etype_name: PATHWAY
+    outs:
+    - path: ../../models/ner_er/model5
+      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+      size: 100224717
+      nfiles: 18
+  interrater:
+    cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+      --output_dir ../../metrics/ner/interrater/
+    deps:
+    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+      md5: 563441b77b5c39063cda3fa0fb03803c
+      size: 883041
+    - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
+      md5: 735cba4532a4c2c5e928399eafc1000f
+      size: 806212
+    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+      md5: 117da032ef2e2792429dff88c06c90b7
+      size: 62653
+    - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+      md5: 6e248863604ce14861f38e7c9a8281bb
+      size: 64285
+    - path: Dockerfile
+      md5: 6bc72a8d70950b3491eb703ffddf7bc0
+      size: 1987
+    - path: interrater.py
+      md5: dd9cabff57a4608753e0777838f9c746
+      size: 2984
+    outs:
+    - path: ../../metrics/ner/interrater/cell_compartment.json
+      md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
+      size: 246
+    - path: ../../metrics/ner/interrater/cell_type.json
+      md5: 5da8476adaad46fd5236dc9da81e8624
+      size: 273
+    - path: ../../metrics/ner/interrater/chemical.json
+      md5: 9842e0e07063f735ecff0bc082999b18
+      size: 260
+    - path: ../../metrics/ner/interrater/condition.json
+      md5: 23eb361695b6b80ccd3e9137a52725c4
+      size: 274
+    - path: ../../metrics/ner/interrater/disease.json
+      md5: 110df2aa12b86f04c19656a43cea8bd2
+      size: 274
+    - path: ../../metrics/ner/interrater/drug.json
+      md5: f58359194658db2bb26483eaf0b931dc
+      size: 260
+    - path: ../../metrics/ner/interrater/organ.json
+      md5: 6652f267bbcc37cd9ac4a9c934085aae
+      size: 261
+    - path: ../../metrics/ner/interrater/organism.json
+      md5: 6e74ba7077e2a999ed6dc598ee78419d
+      size: 274
+    - path: ../../metrics/ner/interrater/pathway.json
+      md5: e038e353873bb5e222e28d6b66d78ee9
+      size: 274
+    - path: ../../metrics/ner/interrater/protein.json
+      md5: 7c7aaf345cba6d103ccf690da0e2f898
+      size: 274

--- a/data_and_models/pipelines/ner/dvc.lock
+++ b/data_and_models/pipelines/ner/dvc.lock
@@ -1,578 +1,572 @@
-schema: '2.0'
-stages:
-  train_model1:
-    cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-      --output_dir ../../models/ner/model1 --model_name model1
-    deps:
-    - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
-      md5: 613308ed830d86284a1aee2747d911d0
-      size: 324136
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: train.py
-      md5: 1ccae6b57456b9e5790a0f1232880f4b
-      size: 2505
-    params:
-      params.yaml:
-        train.model1:
-          prodigy_train_kwargs:
-            spacy_model: en_ner_bc5cdr_md
-            eval_split: 0.1
-            n_iter: 10
-            dropout: 0.2
-    outs:
-    - path: ../../models/ner/model1
-      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-  train_model2:
-    cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-      --output_dir ../../models/ner/model2 --model_name model2
-    deps:
-    - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
-      md5: 2459e49418599ff96ab9db60a29b757b
-      size: 953728
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: train.py
-      md5: 1ccae6b57456b9e5790a0f1232880f4b
-      size: 2505
-    params:
-      params.yaml:
-        train.model2:
-          prodigy_train_kwargs:
-            spacy_model: en_ner_bionlp13cg_md
-            eval_split: 0.1
-            n_iter: 10
-            dropout: 0.2
-    outs:
-    - path: ../../models/ner/model2
-      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-  train_model3:
-    cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-      --output_dir ../../models/ner/model3 --model_name model3
-    deps:
-    - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
-      md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
-      size: 969928
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: train.py
-      md5: 1ccae6b57456b9e5790a0f1232880f4b
-      size: 2505
-    params:
-      params.yaml:
-        train.model3:
-          prodigy_train_kwargs:
-            spacy_model: en_ner_craft_md
-            eval_split: 0.1
-            n_iter: 10
-            dropout: 0.2
-    outs:
-    - path: ../../models/ner/model3
-      md5: 1e6e071c4a730f49f671155e2c6065db.dir
-  train_model4:
-    cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-      --output_dir ../../models/ner/model4 --model_name model4
-    deps:
-    - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
-      md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
-      size: 267307
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: train.py
-      md5: 1ccae6b57456b9e5790a0f1232880f4b
-      size: 2505
-    params:
-      params.yaml:
-        train.model4:
-          prodigy_train_kwargs:
-            spacy_model: en_ner_jnlpba_md
-            eval_split: 0.1
-            n_iter: 10
-            dropout: 0.2
-    outs:
-    - path: ../../models/ner/model4
-      md5: 60213648fac010c178b81983ff76492b.dir
-  train_model5:
-    cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-      --output_dir ../../models/ner/model5 --model_name model5
-    deps:
-    - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
-      md5: ceb6ea77d2a6a69962b88218f4f5a663
-      size: 394725
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: train.py
-      md5: 1ccae6b57456b9e5790a0f1232880f4b
-      size: 2505
-    params:
-      params.yaml:
-        train.model5:
-          prodigy_train_kwargs:
-            spacy_model: en_ner_craft_md
-            eval_split: 0.1
-            n_iter: 10
-            dropout: 0.2
-    outs:
-    - path: ../../models/ner/model5
-      md5: aab9909077d22a91c01042bf7468e80d.dir
-  eval_disease:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
-      --etype DISEASE
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model1
-      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-      size: 100183520
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.DISEASE:
-          etype_name: DISEASE
-    outs:
-    - path: ../../metrics/ner/disease.json
-      md5: 034f6a3ffaabe1fdb4c0900b1c719fac
-      size: 273
-  eval_cell_compartment:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
-      --etype CELL_COMPARTMENT
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model2
-      md5: bf09a6293528ff512e97e8eca8420f33.dir
-      size: 100194437
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.CELL_COMPARTMENT:
-          etype_name: CELLULAR_COMPONENT
-    outs:
-    - path: ../../metrics/ner/cell_compartment.json
-      md5: 0dc8d0f92415d14edfa7cdc8e5381c65
-      size: 260
-  eval_drug:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json
-      --etype DRUG
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model2
-      md5: bf09a6293528ff512e97e8eca8420f33.dir
-      size: 100194437
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.DRUG:
-          etype_name: SIMPLE_CHEMICAL
-    outs:
-    - path: ../../metrics/ner/drug.json
-      md5: 27d7edd2cf470318fcf8be22f3610c0c
-      size: 272
-  eval_organ:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
-      --etype ORGAN
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model2
-      md5: bf09a6293528ff512e97e8eca8420f33.dir
-      size: 100194437
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.ORGAN:
-          etype_name: ORGAN
-    outs:
-    - path: ../../metrics/ner/organ.json
-      md5: 55df17bf18a84a6ef670ae8b2e80af73
-      size: 275
-  eval_chemical:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
-      --etype CHEMICAL
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model3
-      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-      size: 100228858
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.CHEMICAL:
-          etype_name: CHEBI
-    outs:
-    - path: ../../metrics/ner/chemical.json
-      md5: c88b746d0d3dbb0a2b1444c3ab64420c
-      size: 259
-  eval_organism:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
-      --etype ORGANISM
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model3
-      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-      size: 100228858
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.ORGANISM:
-          etype_name: TAXON
-    outs:
-    - path: ../../metrics/ner/organism.json
-      md5: cb2fbe378ad643be3ab2d01b7350e591
-      size: 275
-  eval_cell_type:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
-      --etype CELL_TYPE
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model4
-      md5: 00b992b7a23d903e5a090657dc6af453.dir
-      size: 100215798
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.CELL_TYPE:
-          etype_name: CELL_TYPE
-    outs:
-    - path: ../../metrics/ner/cell_type.json
-      md5: 690a1b81737164cfed2553c9e6852ca2
-      size: 272
-  eval_protein:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
-      --etype PROTEIN
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model4
-      md5: 00b992b7a23d903e5a090657dc6af453.dir
-      size: 100215798
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.PROTEIN:
-          etype_name: PROTEIN
-    outs:
-    - path: ../../metrics/ner/protein.json
-      md5: 5c0de70df94fddcbadbb1206e257efc8
-      size: 263
-  eval_pathway:
-    cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
-      --etype PATHWAY
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../models/ner_er/model5
-      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-      size: 100224717
-      nfiles: 18
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: eval.py
-      md5: 3c9e86f7cbfaea90929e96a6443a16d4
-      size: 3391
-    params:
-      params.yaml:
-        eval.PATHWAY:
-          etype_name: PATHWAY
-    outs:
-    - path: ../../metrics/ner/pathway.json
-      md5: 372df4c2666d0d12215d4189216fa783
-      size: 274
-  add_er_1:
-    cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
-      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
-    deps:
-    - path: ../../annotations/ner/rule_based_patterns.jsonl
-      md5: 044c1a326c2472aa4eb72c4c98a7400b
-      size: 1709
-    - path: ../../models/ner/model1
-      md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
-      size: 100181750
-      nfiles: 16
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: add_er.py
-      md5: dc7fbe1d2370f056eef99dad7c9da011
-      size: 2833
-    params:
-      params.yaml:
-        eval.DISEASE:
-          etype_name: DISEASE
-    outs:
-    - path: ../../models/ner_er/model1
-      md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
-      size: 100183520
-      nfiles: 18
-  add_er_2:
-    cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
-      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-      ../../models/ner_er/model2
-    deps:
-    - path: ../../annotations/ner/rule_based_patterns.jsonl
-      md5: 044c1a326c2472aa4eb72c4c98a7400b
-      size: 1709
-    - path: ../../models/ner/model2
-      md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
-      size: 100192674
-      nfiles: 16
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: add_er.py
-      md5: dc7fbe1d2370f056eef99dad7c9da011
-      size: 2833
-    params:
-      params.yaml:
-        eval.CELL_COMPARTMENT:
-          etype_name: CELLULAR_COMPONENT
-        eval.DRUG:
-          etype_name: SIMPLE_CHEMICAL
-        eval.ORGAN:
-          etype_name: ORGAN
-    outs:
-    - path: ../../models/ner_er/model2
-      md5: bf09a6293528ff512e97e8eca8420f33.dir
-      size: 100194437
-      nfiles: 18
-  add_er_3:
-    cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
-      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-      ../../models/ner_er/model3
-    deps:
-    - path: ../../annotations/ner/rule_based_patterns.jsonl
-      md5: 044c1a326c2472aa4eb72c4c98a7400b
-      size: 1709
-    - path: ../../models/ner/model3
-      md5: 1e6e071c4a730f49f671155e2c6065db.dir
-      size: 100227109
-      nfiles: 16
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: add_er.py
-      md5: dc7fbe1d2370f056eef99dad7c9da011
-      size: 2833
-    params:
-      params.yaml:
-        eval.CHEMICAL:
-          etype_name: CHEBI
-        eval.ORGANISM:
-          etype_name: TAXON
-    outs:
-    - path: ../../models/ner_er/model3
-      md5: 77dcf53eead91718cfdbf087b0901a1a.dir
-      size: 100228858
-      nfiles: 18
-  add_er_4:
-    cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
-      --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
-      ../../models/ner_er/model4
-    deps:
-    - path: ../../annotations/ner/rule_based_patterns.jsonl
-      md5: 044c1a326c2472aa4eb72c4c98a7400b
-      size: 1709
-    - path: ../../models/ner/model4
-      md5: 60213648fac010c178b81983ff76492b.dir
-      size: 100214049
-      nfiles: 16
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: add_er.py
-      md5: dc7fbe1d2370f056eef99dad7c9da011
-      size: 2833
-    params:
-      params.yaml:
-        eval.CELL_TYPE:
-          etype_name: CELL_TYPE
-        eval.PROTEIN:
-          etype_name: PROTEIN
-    outs:
-    - path: ../../models/ner_er/model4
-      md5: 00b992b7a23d903e5a090657dc6af453.dir
-      size: 100215798
-      nfiles: 18
-  add_er_5:
-    cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
-      ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
-    deps:
-    - path: ../../annotations/ner/rule_based_patterns.jsonl
-      md5: 044c1a326c2472aa4eb72c4c98a7400b
-      size: 1709
-    - path: ../../models/ner/model5
-      md5: aab9909077d22a91c01042bf7468e80d.dir
-      size: 100222954
-      nfiles: 16
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: add_er.py
-      md5: dc7fbe1d2370f056eef99dad7c9da011
-      size: 2833
-    params:
-      params.yaml:
-        eval.PATHWAY:
-          etype_name: PATHWAY
-    outs:
-    - path: ../../models/ner_er/model5
-      md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
-      size: 100224717
-      nfiles: 18
-  interrater:
-    cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-      --output_dir ../../metrics/ner/interrater/
-    deps:
-    - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
-      md5: 563441b77b5c39063cda3fa0fb03803c
-      size: 883041
-    - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
-      md5: 735cba4532a4c2c5e928399eafc1000f
-      size: 806212
-    - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
-      md5: 117da032ef2e2792429dff88c06c90b7
-      size: 62653
-    - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
-      md5: 6e248863604ce14861f38e7c9a8281bb
-      size: 64285
-    - path: Dockerfile
-      md5: 6bc72a8d70950b3491eb703ffddf7bc0
-      size: 1987
-    - path: interrater.py
-      md5: dd9cabff57a4608753e0777838f9c746
-      size: 2984
-    outs:
-    - path: ../../metrics/ner/interrater/cell_compartment.json
-      md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
-      size: 246
-    - path: ../../metrics/ner/interrater/cell_type.json
-      md5: 5da8476adaad46fd5236dc9da81e8624
-      size: 273
-    - path: ../../metrics/ner/interrater/chemical.json
-      md5: 9842e0e07063f735ecff0bc082999b18
-      size: 260
-    - path: ../../metrics/ner/interrater/condition.json
-      md5: 23eb361695b6b80ccd3e9137a52725c4
-      size: 274
-    - path: ../../metrics/ner/interrater/disease.json
-      md5: 110df2aa12b86f04c19656a43cea8bd2
-      size: 274
-    - path: ../../metrics/ner/interrater/drug.json
-      md5: f58359194658db2bb26483eaf0b931dc
-      size: 260
-    - path: ../../metrics/ner/interrater/organ.json
-      md5: 6652f267bbcc37cd9ac4a9c934085aae
-      size: 261
-    - path: ../../metrics/ner/interrater/organism.json
-      md5: 6e74ba7077e2a999ed6dc598ee78419d
-      size: 274
-    - path: ../../metrics/ner/interrater/pathway.json
-      md5: e038e353873bb5e222e28d6b66d78ee9
-      size: 274
-    - path: ../../metrics/ner/interrater/protein.json
-      md5: 7c7aaf345cba6d103ccf690da0e2f898
-      size: 274
+train_model1:
+  cmd: python train.py --annotation_files ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+    --output_dir ../../models/ner/model1 --model_name model1
+  deps:
+  - path: ../../annotations/ner/annotations5_EmmanuelleLogette_2020-06-30_raw2_Disease.jsonl
+    md5: 613308ed830d86284a1aee2747d911d0
+    size: 324136
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: train.py
+    md5: 1ccae6b57456b9e5790a0f1232880f4b
+    size: 2505
+  params:
+    params.yaml:
+      train.model1:
+        prodigy_train_kwargs:
+          spacy_model: en_ner_bc5cdr_md
+          eval_split: 0.1
+          n_iter: 10
+          dropout: 0.2
+  outs:
+  - path: ../../models/ner/model1
+    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+train_model2:
+  cmd: python train.py --annotation_files ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+    --output_dir ../../models/ner/model2 --model_name model2
+  deps:
+  - path: ../../annotations/ner/annotations14_EmmanuelleLogette_2020-09-02_raw8_CellCompartmentDrugOrgan.jsonl
+    md5: 2459e49418599ff96ab9db60a29b757b
+    size: 953728
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: train.py
+    md5: 1ccae6b57456b9e5790a0f1232880f4b
+    size: 2505
+  params:
+    params.yaml:
+      train.model2:
+        prodigy_train_kwargs:
+          spacy_model: en_ner_bionlp13cg_md
+          eval_split: 0.1
+          n_iter: 10
+          dropout: 0.2
+  outs:
+  - path: ../../models/ner/model2
+    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+train_model3:
+  cmd: python train.py --annotation_files ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+    --output_dir ../../models/ner/model3 --model_name model3
+  deps:
+  - path: ../../annotations/ner/annotations6_EmmanuelleLogette_2020-07-07_raw4_TaxonChebi.jsonl
+    md5: 4b6fff4b0091fa10ae7c88a4aeb42ae0
+    size: 969928
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: train.py
+    md5: 1ccae6b57456b9e5790a0f1232880f4b
+    size: 2505
+  params:
+    params.yaml:
+      train.model3:
+        prodigy_train_kwargs:
+          spacy_model: en_ner_craft_md
+          eval_split: 0.1
+          n_iter: 10
+          dropout: 0.2
+  outs:
+  - path: ../../models/ner/model3
+    md5: 1e6e071c4a730f49f671155e2c6065db.dir
+train_model4:
+  cmd: python train.py --annotation_files ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+    --output_dir ../../models/ner/model4 --model_name model4
+  deps:
+  - path: ../../annotations/ner/annotations9_EmmanuelleLogette_2020-07-08_raw6_CelltypeProtein.jsonl
+    md5: ec5d6b86181b9e4cdefb2b2198d5ae4f
+    size: 267307
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: train.py
+    md5: 1ccae6b57456b9e5790a0f1232880f4b
+    size: 2505
+  params:
+    params.yaml:
+      train.model4:
+        prodigy_train_kwargs:
+          spacy_model: en_ner_jnlpba_md
+          eval_split: 0.1
+          n_iter: 10
+          dropout: 0.2
+  outs:
+  - path: ../../models/ner/model4
+    md5: 60213648fac010c178b81983ff76492b.dir
+train_model5:
+  cmd: python train.py --annotation_files ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+    --output_dir ../../models/ner/model5 --model_name model5
+  deps:
+  - path: ../../annotations/ner/annotations15_EmmanuelleLogette_2020-09-22_raw9_Pathway.jsonl
+    md5: ceb6ea77d2a6a69962b88218f4f5a663
+    size: 394725
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: train.py
+    md5: 1ccae6b57456b9e5790a0f1232880f4b
+    size: 2505
+  params:
+    params.yaml:
+      train.model5:
+        prodigy_train_kwargs:
+          spacy_model: en_ner_craft_md
+          eval_split: 0.1
+          n_iter: 10
+          dropout: 0.2
+  outs:
+  - path: ../../models/ner/model5
+    md5: aab9909077d22a91c01042bf7468e80d.dir
+eval_disease:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model1 --output_file ../../metrics/ner/disease.json
+    --etype DISEASE
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model1
+    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+    size: 100183520
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.DISEASE:
+        etype_name: DISEASE
+  outs:
+  - path: ../../metrics/ner/disease.json
+    md5: 034f6a3ffaabe1fdb4c0900b1c719fac
+    size: 273
+eval_cell_compartment:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/cell_compartment.json
+    --etype CELL_COMPARTMENT
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model2
+    md5: bf09a6293528ff512e97e8eca8420f33.dir
+    size: 100194437
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.CELL_COMPARTMENT:
+        etype_name: CELLULAR_COMPONENT
+  outs:
+  - path: ../../metrics/ner/cell_compartment.json
+    md5: 0dc8d0f92415d14edfa7cdc8e5381c65
+    size: 260
+eval_drug:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/drug.json --etype
+    DRUG
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model2
+    md5: bf09a6293528ff512e97e8eca8420f33.dir
+    size: 100194437
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.DRUG:
+        etype_name: SIMPLE_CHEMICAL
+  outs:
+  - path: ../../metrics/ner/drug.json
+    md5: 27d7edd2cf470318fcf8be22f3610c0c
+eval_organ:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model2 --output_file ../../metrics/ner/organ.json
+    --etype ORGAN
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model2
+    md5: bf09a6293528ff512e97e8eca8420f33.dir
+    size: 100194437
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.ORGAN:
+        etype_name: ORGAN
+  outs:
+  - path: ../../metrics/ner/organ.json
+    md5: 55df17bf18a84a6ef670ae8b2e80af73
+    size: 275
+eval_chemical:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/chemical.json
+    --etype CHEMICAL
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model3
+    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+    size: 100228858
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.CHEMICAL:
+        etype_name: CHEBI
+  outs:
+  - path: ../../metrics/ner/chemical.json
+    md5: c88b746d0d3dbb0a2b1444c3ab64420c
+eval_organism:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model3 --output_file ../../metrics/ner/organism.json
+    --etype ORGANISM
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model3
+    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+    size: 100228858
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.ORGANISM:
+        etype_name: TAXON
+  outs:
+  - path: ../../metrics/ner/organism.json
+    md5: cb2fbe378ad643be3ab2d01b7350e591
+eval_cell_type:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/cell_type.json
+    --etype CELL_TYPE
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model4
+    md5: 00b992b7a23d903e5a090657dc6af453.dir
+    size: 100215798
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.CELL_TYPE:
+        etype_name: CELL_TYPE
+  outs:
+  - path: ../../metrics/ner/cell_type.json
+    md5: 690a1b81737164cfed2553c9e6852ca2
+    size: 272
+eval_protein:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model4 --output_file ../../metrics/ner/protein.json
+    --etype PROTEIN
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model4
+    md5: 00b992b7a23d903e5a090657dc6af453.dir
+    size: 100215798
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.PROTEIN:
+        etype_name: PROTEIN
+  outs:
+  - path: ../../metrics/ner/protein.json
+    md5: 5c0de70df94fddcbadbb1206e257efc8
+    size: 263
+eval_pathway:
+  cmd: python eval.py --annotation_files ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --model ../../models/ner_er/model5 --output_file ../../metrics/ner/pathway.json
+    --etype PATHWAY
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../models/ner_er/model5
+    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+    size: 100224717
+    nfiles: 18
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: eval.py
+    md5: 3c9e86f7cbfaea90929e96a6443a16d4
+    size: 3391
+  params:
+    params.yaml:
+      eval.PATHWAY:
+        etype_name: PATHWAY
+  outs:
+  - path: ../../metrics/ner/pathway.json
+    md5: 372df4c2666d0d12215d4189216fa783
+add_er_1:
+  cmd: python add_er.py --model ../../models/ner/model1 --etypes DISEASE --patterns_file
+    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model1
+  deps:
+  - path: ../../annotations/ner/rule_based_patterns.jsonl
+    md5: 044c1a326c2472aa4eb72c4c98a7400b
+    size: 1709
+  - path: ../../models/ner/model1
+    md5: 4c687b7dd44d0f7adc2d3df2e2e4f624.dir
+    size: 100181750
+    nfiles: 16
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: add_er.py
+    md5: aafbf109663670ded44f84025e4a37a3
+    size: 2531
+  params:
+    params.yaml:
+      eval.DISEASE:
+        etype_name: DISEASE
+  outs:
+  - path: ../../models/ner_er/model1
+    md5: 5757d1ea583e2ac6aa7e642e11b56325.dir
+    size: 100183520
+    nfiles: 18
+add_er_2:
+  cmd: python add_er.py --model ../../models/ner/model2 --etypes CELL_COMPARTMENT,DRUG,ORGAN
+    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+    ../../models/ner_er/model2
+  deps:
+  - path: ../../annotations/ner/rule_based_patterns.jsonl
+    md5: 044c1a326c2472aa4eb72c4c98a7400b
+    size: 1709
+  - path: ../../models/ner/model2
+    md5: 2e3337ad9af49c9fef0332b6c3ad0832.dir
+    size: 100192674
+    nfiles: 16
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: add_er.py
+    md5: aafbf109663670ded44f84025e4a37a3
+    size: 2531
+  params:
+    params.yaml:
+      eval.CELL_COMPARTMENT:
+        etype_name: CELLULAR_COMPONENT
+      eval.DRUG:
+        etype_name: SIMPLE_CHEMICAL
+      eval.ORGAN:
+        etype_name: ORGAN
+  outs:
+  - path: ../../models/ner_er/model2
+    md5: bf09a6293528ff512e97e8eca8420f33.dir
+    size: 100194437
+    nfiles: 18
+add_er_3:
+  cmd: python add_er.py --model ../../models/ner/model3 --etypes CHEMICAL,ORGANISM
+    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+    ../../models/ner_er/model3
+  deps:
+  - path: ../../annotations/ner/rule_based_patterns.jsonl
+    md5: 044c1a326c2472aa4eb72c4c98a7400b
+    size: 1709
+  - path: ../../models/ner/model3
+    md5: 1e6e071c4a730f49f671155e2c6065db.dir
+    size: 100227109
+    nfiles: 16
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: add_er.py
+    md5: aafbf109663670ded44f84025e4a37a3
+    size: 2531
+  params:
+    params.yaml:
+      eval.CHEMICAL:
+        etype_name: CHEBI
+      eval.ORGANISM:
+        etype_name: TAXON
+  outs:
+  - path: ../../models/ner_er/model3
+    md5: 77dcf53eead91718cfdbf087b0901a1a.dir
+    size: 100228858
+    nfiles: 18
+add_er_4:
+  cmd: python add_er.py --model ../../models/ner/model4 --etypes CELL_TYPE,PROTEIN
+    --patterns_file ../../annotations/ner/rule_based_patterns.jsonl --output_file
+    ../../models/ner_er/model4
+  deps:
+  - path: ../../annotations/ner/rule_based_patterns.jsonl
+    md5: 044c1a326c2472aa4eb72c4c98a7400b
+    size: 1709
+  - path: ../../models/ner/model4
+    md5: 60213648fac010c178b81983ff76492b.dir
+    size: 100214049
+    nfiles: 16
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: add_er.py
+    md5: aafbf109663670ded44f84025e4a37a3
+    size: 2531
+  params:
+    params.yaml:
+      eval.CELL_TYPE:
+        etype_name: CELL_TYPE
+      eval.PROTEIN:
+        etype_name: PROTEIN
+  outs:
+  - path: ../../models/ner_er/model4
+    md5: 00b992b7a23d903e5a090657dc6af453.dir
+    size: 100215798
+    nfiles: 18
+add_er_5:
+  cmd: python add_er.py --model ../../models/ner/model5 --etypes PATHWAY --patterns_file
+    ../../annotations/ner/rule_based_patterns.jsonl --output_file ../../models/ner_er/model5
+  deps:
+  - path: ../../annotations/ner/rule_based_patterns.jsonl
+    md5: 044c1a326c2472aa4eb72c4c98a7400b
+    size: 1709
+  - path: ../../models/ner/model5
+    md5: aab9909077d22a91c01042bf7468e80d.dir
+    size: 100222954
+    nfiles: 16
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: add_er.py
+    md5: aafbf109663670ded44f84025e4a37a3
+    size: 2531
+  params:
+    params.yaml:
+      eval.PATHWAY:
+        etype_name: PATHWAY
+  outs:
+  - path: ../../models/ner_er/model5
+    md5: 958f3d6edfb8216c31d39af0032ee4a9.dir
+    size: 100224717
+    nfiles: 18
+interrater:
+  cmd: python interrater.py --annotations1 ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl,../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    --annotations2 ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl,../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+    --output_dir ../../metrics/ner/interrater/
+  deps:
+  - path: ../../annotations/ner/annotations10_EmmanuelleLogette_2020-08-28_raw1_raw5_10EntityTypes.jsonl
+    md5: 563441b77b5c39063cda3fa0fb03803c
+    size: 883041
+  - path: ../../annotations/ner/annotations11_CharlotteLorin_2020-08-28_raw1_10EntityTypes.jsonl
+    md5: 735cba4532a4c2c5e928399eafc1000f
+    size: 806212
+  - path: ../../annotations/ner/annotations12_EmmanuelleLogette_2020-08-28_raw7_10EntityTypes.jsonl
+    md5: 117da032ef2e2792429dff88c06c90b7
+    size: 62653
+  - path: ../../annotations/ner/annotations13_CharlotteLorin_2020-09-02_raw7_10EntityTypes.jsonl
+    md5: 6e248863604ce14861f38e7c9a8281bb
+    size: 64285
+  - path: Dockerfile
+    md5: da73fa137594c015a32f36ebc772f553
+    size: 1987
+  - path: interrater.py
+    md5: dd9cabff57a4608753e0777838f9c746
+    size: 2984
+  outs:
+  - path: ../../metrics/ner/interrater/cell_compartment.json
+    md5: 1c5c2f5fb7dc7f792f4a3a974fe753f8
+    size: 246
+  - path: ../../metrics/ner/interrater/cell_type.json
+    md5: 5da8476adaad46fd5236dc9da81e8624
+    size: 273
+  - path: ../../metrics/ner/interrater/chemical.json
+    md5: 9842e0e07063f735ecff0bc082999b18
+    size: 260
+  - path: ../../metrics/ner/interrater/condition.json
+    md5: 23eb361695b6b80ccd3e9137a52725c4
+    size: 274
+  - path: ../../metrics/ner/interrater/disease.json
+    md5: 110df2aa12b86f04c19656a43cea8bd2
+    size: 274
+  - path: ../../metrics/ner/interrater/drug.json
+    md5: f58359194658db2bb26483eaf0b931dc
+    size: 260
+  - path: ../../metrics/ner/interrater/organ.json
+    md5: 6652f267bbcc37cd9ac4a9c934085aae
+    size: 261
+  - path: ../../metrics/ner/interrater/organism.json
+    md5: 6e74ba7077e2a999ed6dc598ee78419d
+    size: 274
+  - path: ../../metrics/ner/interrater/pathway.json
+    md5: e038e353873bb5e222e28d6b66d78ee9
+    size: 274
+  - path: ../../metrics/ner/interrater/protein.json
+    md5: 7c7aaf345cba6d103ccf690da0e2f898
+    size: 274

--- a/data_and_models/pipelines/sentence_embedding/Dockerfile
+++ b/data_and_models/pipelines/sentence_embedding/Dockerfile
@@ -30,7 +30,7 @@ RUN true \
 RUN conda install -c carta mysqlclient
 
 # Instal BlueBrainSearach -- revision can be a branch, sha, or tag
-ARG BBS_REVISION=v0.1.0
+ARG BBS_REVISION=v0.1.1
 ADD . /src
 WORKDIR /src
 RUN git checkout $BBS_REVISION

--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -49,8 +49,8 @@ stages:
             lowercase: true
     outs:
     - path: ../../models/sentence_embedding/tf_idf
-      md5: d6ee9bd093dae907cc0db086c8be833e.dir
-      size: 88474206
+      md5: ed37b15fe3406ab6c36f255f23d155a2.dir
+      size: 73231015
       nfiles: 1
   eval_tf_idf:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -105,8 +105,8 @@ stages:
             lowercase: true
     outs:
     - path: ../../models/sentence_embedding/count
-      md5: a40cb29080c7f688da1a9bba86538aec.dir
-      size: 53618191
+      md5: 8a0b977a24fe5ed2293c3fcd0288a138.dir
+      size: 38375243
       nfiles: 1
   eval_count:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv

--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -1,228 +1,230 @@
-eval_biobert_nli_sts:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=biobert_nli_sts --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.biobert_nli_sts:
-        class: SentTransformer
-        init_kwargs:
-          model_name_or_path: clagator/biobert_v1.1_pubmed_nli_sts
-  outs:
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts.csv
-    md5: fae1c6d3a8efb3354dc3d81682491a07
-    size: 1247
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts.json
-    md5: 07ceb39e7a538a28f569e09f01ae56b1
-    size: 104
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts.png
-    md5: 86db1f66aaa757523aef3f04088cddfd
-    size: 153514
-train_tf_idf:
-  cmd: python train.py --sentences_file=../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
-    --model=tf_idf --output_dir=../../models/sentence_embedding/tf_idf
-  deps:
-  - path: ../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
-    md5: d0c68b698738f714df81eb5fb29236fe
-    size: 2202482311
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: train.py
-    md5: 3a3955f5cbfe1e1bf53701b69e7f1857
-    size: 3138
-  params:
-    params.yaml:
-      train.tf_idf:
-        init_kwargs:
-          lowercase: true
-  outs:
-  - path: ../../models/sentence_embedding/tf_idf
-    md5: ed37b15fe3406ab6c36f255f23d155a2.dir
-    size: 73231015
-    nfiles: 1
-eval_tf_idf:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=tf_idf --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: ../../models/sentence_embedding/tf_idf
-    md5: ed37b15fe3406ab6c36f255f23d155a2.dir
-    size: 73231015
-    nfiles: 1
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.tf_idf:
-        class: SklearnVectorizer
-        init_kwargs:
-          checkpoint_path: ../../models/sentence_embedding/tf_idf/model.pkl
-  outs:
-  - path: ../../metrics/sentence_embedding/tf_idf.csv
-    md5: 212b39946c23a416a0056b5e48136b31
-    size: 596
-  - path: ../../metrics/sentence_embedding/tf_idf.json
-    md5: 5d8beda62321460ed2221329b60d506a
-    size: 106
-  - path: ../../metrics/sentence_embedding/tf_idf.png
-    md5: 4f814f17e4d070a44fb1ac181f638654
-    size: 86578
-train_count:
-  cmd: python train.py --sentences_file=../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
-    --model=count --output_dir=../../models/sentence_embedding/count
-  deps:
-  - path: ../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
-    md5: d0c68b698738f714df81eb5fb29236fe
-    size: 2202482311
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: train.py
-    md5: 3a3955f5cbfe1e1bf53701b69e7f1857
-    size: 3138
-  params:
-    params.yaml:
-      train.count:
-        init_kwargs:
-          lowercase: true
-  outs:
-  - path: ../../models/sentence_embedding/count
-    md5: 8a0b977a24fe5ed2293c3fcd0288a138.dir
-    size: 38375243
-    nfiles: 1
-eval_count:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=count --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: ../../models/sentence_embedding/count
-    md5: 8a0b977a24fe5ed2293c3fcd0288a138.dir
-    size: 38375243
-    nfiles: 1
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.count:
-        class: SklearnVectorizer
-        init_kwargs:
-          checkpoint_path: ../../models/sentence_embedding/count/model.pkl
-  outs:
-  - path: ../../metrics/sentence_embedding/count.csv
-    md5: de5820a6b76984ac81eed350a1807f88
-    size: 611
-  - path: ../../metrics/sentence_embedding/count.json
-    md5: 90ca5beef27c502587f20bfcf6187283
-    size: 105
-  - path: ../../metrics/sentence_embedding/count.png
-    md5: 4f814f17e4d070a44fb1ac181f638654
-    size: 86578
-eval_sbert:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=sbert --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.sbert:
-        class: SentTransformer
-        init_kwargs:
-          model_name_or_path: bert-base-nli-mean-tokens
-  outs:
-  - path: ../../metrics/sentence_embedding/sbert.csv
-    md5: 122f6acb30f412302775c51486c27ed4
-    size: 1224
-  - path: ../../metrics/sentence_embedding/sbert.json
-    md5: ea9c4003ca96c0a16ad5c971e447fee6
-    size: 107
-  - path: ../../metrics/sentence_embedding/sbert.png
-    md5: 3a6f531fec2c30662ee4e523976ff048
-    size: 156836
-eval_sbiobert:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=sbiobert --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: Dockerfile
-    md5: 3998f44b16bc0561c198792d61843d81
-    size: 1735
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.sbiobert:
-        class: SBioBERT
-        init_kwargs: {}
-  outs:
-  - path: ../../metrics/sentence_embedding/sbiobert.csv
-    md5: e1b06106de5f9b4d19bb5944254c1615
-    size: 1201
-  - path: ../../metrics/sentence_embedding/sbiobert.json
-    md5: aaba862daa19f719258ce728c0b226ad
-    size: 105
-  - path: ../../metrics/sentence_embedding/sbiobert.png
-    md5: ddf8088966ccc676ca449eada9364c1a
-    size: 155274
-eval_biobert_nli_sts_cord19_v1:
-  cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    --model=biobert_nli_sts_cord19_v1 --output_dir=../../metrics/sentence_embedding
-  deps:
-  - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-    md5: 92a4235ce8d292ff382ce008c31da45c
-    size: 14587
-  - path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1
-    md5: 9dccac418759a8c53f5da608dbd9f835.dir
-    size: 433540587
-    nfiles: 9
-  - path: eval.py
-    md5: 344dab3249c0017493c02ef68facf4e8
-    size: 4557
-  params:
-    params.yaml:
-      eval.biobert_nli_sts_cord19_v1:
-        class: SentTransformer
-        init_kwargs:
-          model_name_or_path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1/
-  outs:
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.csv
-    md5: f80bd92608012c65ede3417b10b0e731
-    size: 1264
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.json
-    md5: c4371ca281d5f224332115f5a31ce9cd
-    size: 104
-  - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.png
-    md5: c310722f7dcac36cae1c25c382cfd89b
-    size: 153802
+schema: '2.0'
+stages:
+  eval_biobert_nli_sts:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=biobert_nli_sts --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.biobert_nli_sts:
+          class: SentTransformer
+          init_kwargs:
+            model_name_or_path: clagator/biobert_v1.1_pubmed_nli_sts
+    outs:
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.csv
+      md5: 9560cc7eeef674eae5af3a29d8dd66c2
+      size: 1256
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.json
+      md5: f6e6b6d190003ea076e689e9e35dcb22
+      size: 104
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.png
+      md5: 86db1f66aaa757523aef3f04088cddfd
+      size: 153514
+  train_tf_idf:
+    cmd: python train.py --sentences_file=../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
+      --model=tf_idf --output_dir=../../models/sentence_embedding/tf_idf
+    deps:
+    - path: ../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
+      md5: d0c68b698738f714df81eb5fb29236fe
+      size: 2202482311
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: train.py
+      md5: 3a3955f5cbfe1e1bf53701b69e7f1857
+      size: 3138
+    params:
+      params.yaml:
+        train.tf_idf:
+          init_kwargs:
+            lowercase: true
+    outs:
+    - path: ../../models/sentence_embedding/tf_idf
+      md5: d6ee9bd093dae907cc0db086c8be833e.dir
+      size: 88474206
+      nfiles: 1
+  eval_tf_idf:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=tf_idf --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: ../../models/sentence_embedding/tf_idf
+      md5: d6ee9bd093dae907cc0db086c8be833e.dir
+      size: 88474206
+      nfiles: 1
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.tf_idf:
+          class: SklearnVectorizer
+          init_kwargs:
+            checkpoint_path: ../../models/sentence_embedding/tf_idf/model.pkl
+    outs:
+    - path: ../../metrics/sentence_embedding/tf_idf.csv
+      md5: 212b39946c23a416a0056b5e48136b31
+      size: 596
+    - path: ../../metrics/sentence_embedding/tf_idf.json
+      md5: 5d8beda62321460ed2221329b60d506a
+      size: 106
+    - path: ../../metrics/sentence_embedding/tf_idf.png
+      md5: 4f814f17e4d070a44fb1ac181f638654
+      size: 86578
+  train_count:
+    cmd: python train.py --sentences_file=../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
+      --model=count --output_dir=../../models/sentence_embedding/count
+    deps:
+    - path: ../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
+      md5: d0c68b698738f714df81eb5fb29236fe
+      size: 2202482311
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: train.py
+      md5: 3a3955f5cbfe1e1bf53701b69e7f1857
+      size: 3138
+    params:
+      params.yaml:
+        train.count:
+          init_kwargs:
+            lowercase: true
+    outs:
+    - path: ../../models/sentence_embedding/count
+      md5: a40cb29080c7f688da1a9bba86538aec.dir
+      size: 53618191
+      nfiles: 1
+  eval_count:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=count --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: ../../models/sentence_embedding/count
+      md5: a40cb29080c7f688da1a9bba86538aec.dir
+      size: 53618191
+      nfiles: 1
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.count:
+          class: SklearnVectorizer
+          init_kwargs:
+            checkpoint_path: ../../models/sentence_embedding/count/model.pkl
+    outs:
+    - path: ../../metrics/sentence_embedding/count.csv
+      md5: de5820a6b76984ac81eed350a1807f88
+      size: 611
+    - path: ../../metrics/sentence_embedding/count.json
+      md5: 90ca5beef27c502587f20bfcf6187283
+      size: 105
+    - path: ../../metrics/sentence_embedding/count.png
+      md5: 4f814f17e4d070a44fb1ac181f638654
+      size: 86578
+  eval_sbert:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=sbert --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.sbert:
+          class: SentTransformer
+          init_kwargs:
+            model_name_or_path: bert-base-nli-mean-tokens
+    outs:
+    - path: ../../metrics/sentence_embedding/sbert.csv
+      md5: 1aa10d5f198369bcaa869e34399e9ac8
+      size: 1209
+    - path: ../../metrics/sentence_embedding/sbert.json
+      md5: fbce52e6829fb6e7e1023a4307a71cfa
+      size: 105
+    - path: ../../metrics/sentence_embedding/sbert.png
+      md5: 3a6f531fec2c30662ee4e523976ff048
+      size: 156836
+  eval_sbiobert:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=sbiobert --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: Dockerfile
+      md5: a11a4c1d4fb63322f5973ed59887fe4f
+      size: 1735
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.sbiobert:
+          class: SBioBERT
+          init_kwargs: {}
+    outs:
+    - path: ../../metrics/sentence_embedding/sbiobert.csv
+      md5: 072055e23136d215e49576c4840ce945
+      size: 1220
+    - path: ../../metrics/sentence_embedding/sbiobert.json
+      md5: 98372b5fc5a303435250579b6346df74
+      size: 105
+    - path: ../../metrics/sentence_embedding/sbiobert.png
+      md5: ddf8088966ccc676ca449eada9364c1a
+      size: 155274
+  eval_biobert_nli_sts_cord19_v1:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=biobert_nli_sts_cord19_v1 --output_dir=../../metrics/sentence_embedding
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1
+      md5: 9dccac418759a8c53f5da608dbd9f835.dir
+      size: 433540587
+      nfiles: 9
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.biobert_nli_sts_cord19_v1:
+          class: SentTransformer
+          init_kwargs:
+            model_name_or_path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1/
+    outs:
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.csv
+      md5: 0af5d8ab4ae30b1eb9472363091b9fed
+      size: 1258
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.json
+      md5: 2cf62421ad0e64750ba4768b1c68cac3
+      size: 104
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.png
+      md5: c310722f7dcac36cae1c25c382cfd89b
+      size: 153802

--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -60,8 +60,8 @@ stages:
       md5: 92a4235ce8d292ff382ce008c31da45c
       size: 14587
     - path: ../../models/sentence_embedding/tf_idf
-      md5: d6ee9bd093dae907cc0db086c8be833e.dir
-      size: 88474206
+      md5: ed37b15fe3406ab6c36f255f23d155a2.dir
+      size: 73231015
       nfiles: 1
     - path: Dockerfile
       md5: a11a4c1d4fb63322f5973ed59887fe4f
@@ -116,8 +116,8 @@ stages:
       md5: 92a4235ce8d292ff382ce008c31da45c
       size: 14587
     - path: ../../models/sentence_embedding/count
-      md5: a40cb29080c7f688da1a9bba86538aec.dir
-      size: 53618191
+      md5: 8a0b977a24fe5ed2293c3fcd0288a138.dir
+      size: 38375243
       nfiles: 1
     - path: Dockerfile
       md5: a11a4c1d4fb63322f5973ed59887fe4f

--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -186,12 +186,13 @@ stages:
     params:
       params.yaml:
         eval.sbiobert:
-          class: SBioBERT
-          init_kwargs: {}
+          class: SentTransformer
+          init_kwargs:
+            model_name_or_path: gsarti/biobert-nli
     outs:
     - path: ../../metrics/sentence_embedding/sbiobert.csv
-      md5: 072055e23136d215e49576c4840ce945
-      size: 1220
+      md5: c2c55aea18b0a4a258c9424d655d25a1
+      size: 1212
     - path: ../../metrics/sentence_embedding/sbiobert.json
       md5: 98372b5fc5a303435250579b6346df74
       size: 105

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -26,9 +26,10 @@ Legend
 - |Deprecate| denotes deprecated features that will be removed in the future.
 - |Remove| denotes removed features.
 
-Latest
-======
-- |Remove| NLTK dependencies
+Version 0.1.1
+=============
+- |Change| Upgrade to :code:`dvc 2.0`.
+- |Remove| NLTK dependencies.
 - |Change| Drop the dedicated :code:`SBioBERT` class, we now use
   :code:`SentTransformer` interface to support this model.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ PyYAML==5.4.1
 SQLAlchemy==1.3.23
 Sphinx==3.5.1
 docker==4.4.3
-dvc[ssh]==1.11.16
+dvc[ssh]==2.0.6
 gunicorn==20.0.4
 h5py==3.1.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-2.3.1/en_core_web_sm-2.3.1.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ INSTALL_REQUIRES = [
     "Flask",
     "PyYAML",
     "SQLAlchemy",
-    "dvc[ssh]",
+    "dvc[ssh]>=2",
     "h5py",
     "ipython",
     "ipywidgets",


### PR DESCRIPTION
Fixes #273.

## Description

Upgrades to `dvc==2.0.6` and releases `bluesearch v0.1.1`.

### Notes
1. I used to consistently get the error 
```ValueError: unsupported pickle protocol: 5```
 when trying to `dvc pull` or `dvc add` using `dvc>=2` in a directory where I still had the old cache generated using `dvc<2`. But for some reason I cannot reproduce the error any more! 🤷  Anyway, should you see that error, try to `rm -rf .dvc/cache` and then re-populate your cache with a `dvc pull` (or `dvc fetch`)—this worked for me.
 2. The new `dvc.lock` format is only slightly different but breaks backward compatibility. Also, `git diff` is confused by the new format, so please see "How to test" below to see how to visualize the changes.
3. Here are some highlights of the new elemnents introduced in `dvc 2.0`.
    1. [**ML experiments**](https://dvc.org/blog/dvc-2-0-release#lightweight-ml-experiments) (beta, may change) lets you try various hyper-parameter configurations in a lightweight way, without having to create a `git branch` for each of them.
    2. [ **`dvc run` deprecated in favor of `dvc stage add`**](https://dvc.org/blog/dvc-2-0-release#ml-model-checkpoints-versioning).
    3. [**Better metrics log and viz**](https://dvc.org/blog/dvc-2-0-release#metrics-logging).


## How to test?
1. To see what _really_ changed in any of the two `dvc.lock` files, other than the new format, please run the following command.
```bash
cp dvc.lock dvc_new.lock
git checkout master -- dvc.lock
vimdiff dvc.lock <(sed "s/^..//" dvc_new.lock | tail -n +3 | cat)  # fix formatting to allow comparison!
```
2. Follow the same steps of "How To Test" from #265, just replacing `v0.1.0` with `v0.1.1`.
## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] All CI tests pass. 
