### PR TITLE
Fix bugs in NER evaluation

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -43,6 +43,8 @@ Latest
 - |Change| :code:`requirements.txt` refactored into three separate lists of
   dependencies: :code:`requirements.txt`, :code:`requirements-dev.txt`,
   :code:`requirements-data_and_models.txt`.
+- |Fix| bugs (related to nested entities) in :code:`ner_report`, :code:`ner_errors`, :code:`ner_confusion_matrix`
+  functions from :code:`bluesearch.mining.eval` submodule.
 
 
 Version 0.1.2

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -43,8 +43,10 @@ Latest
 - |Change| :code:`requirements.txt` refactored into three separate lists of
   dependencies: :code:`requirements.txt`, :code:`requirements-dev.txt`,
   :code:`requirements-data_and_models.txt`.
-- |Fix| bugs (related to nested entities) in :code:`ner_report`, :code:`ner_errors`, :code:`ner_confusion_matrix`
-  functions from :code:`bluesearch.mining.eval` submodule.
+- |Fix| bugs (related to nested entities) in :code:`ner_report`, :code:`ner_errors`,
+  :code:`ner_confusion_matrix` functions from :code:`bluesearch.mining.eval` submodule.
+- |Add| utility function :code:`_check_consistent_iob` inside
+  :code:`bluesearch.mining.eval`.
 
 
 Version 0.1.2

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -300,7 +300,7 @@ def compute_database_embeddings(connection, model, indices, batch_size=10):
 def get_embedding_model(
     model_name_or_class: str,
     checkpoint_path: Optional[Union[pathlib.Path, str]] = None,
-    device: Optional[str] = "cpu",
+    device: str = "cpu",
 ) -> EmbeddingModel:
     """Load a sentence embedding model from its name or its class and checkpoint.
 

--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -374,9 +374,9 @@ def idx2text(tokens, idxs):
 def ner_report(
     iob_true: pd.Series,
     iob_pred: pd.Series,
-    mode: Optional[str] = "entity",
+    mode: str = "entity",
     etypes_map: Optional[dict] = None,
-    return_dict: Optional[bool] = False,
+    return_dict: bool = False,
 ) -> Union[str, OrderedDict]:
     """Build a summary report showing the main ner evaluation metrics.
 
@@ -488,9 +488,9 @@ def ner_errors(
     iob_true: pd.Series,
     iob_pred: pd.Series,
     tokens: pd.Series,
-    mode: Optional[str] = "entity",
+    mode: str = "entity",
     etypes_map: Optional[dict] = None,
-    return_dict: Optional[bool] = False,
+    return_dict: bool = False,
 ) -> Union[str, OrderedDict]:
     """Build a summary report for the named entity recognition.
 
@@ -599,7 +599,7 @@ def ner_confusion_matrix(
     iob_true: pd.Series,
     iob_pred: pd.Series,
     normalize: Optional[str] = None,
-    mode: Optional[str] = "entity",
+    mode: str = "entity",
 ) -> pd.DataFrame:
     """Compute confusion matrix to evaluate the accuracy of a NER model.
 
@@ -612,7 +612,7 @@ def ner_confusion_matrix(
     iob_pred :
         Predicted IOB2 annotations.
     normalize :
-        One of "true", "pred", "all".
+        One of "true", "pred", "all", or None.
         Normalizes confusion matrix over the true (rows), predicted (columns)
         conditions or all the population. If None, the confusion matrix will
         not be normalized.

--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -36,7 +36,6 @@ def _check_consistent_iob(iob_true: pd.Series, iob_pred: pd.Series) -> None:
 
     This function raises a ValueError if any of the targets uses an annotation
     format different from IOB2 (see [1] for the definition of this format).
-    For more
 
     Parameters
     ----------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,8 @@ def ner_annotations():
                 "text": [
                     "Either",
                     "influenza",
-                    "or" "Sars",
+                    "or",
+                    "Sars",
                     "Cov-2",
                     "infection",
                     "disease",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -400,6 +400,12 @@ def ner_annotations():
                 ],
             }
         ),
+        "sample_nested": pd.DataFrame(
+            data={
+                "annotator_1": ["B-a", "B-a", "I-a", "I-a"],
+                "annotator_2": ["B-z", "B-z", "B-z", "I-z"],
+            }
+        ),
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,8 +402,16 @@ def ner_annotations():
         ),
         "sample_nested": pd.DataFrame(
             data={
-                "annotator_1": ["B-a", "B-a", "I-a", "I-a"],
-                "annotator_2": ["B-z", "B-z", "B-z", "I-z"],
+                "annotator_1": ["O", "B-a", "O", "B-a", "I-a", "I-a", "O"],
+                "annotator_2": ["O", "B-a", "O", "B-a", "B-a", "I-a", "B-a"],
+                "text": [
+                    "Either",
+                    "influenza",
+                    "or" "Sars",
+                    "Cov-2",
+                    "infection",
+                    "disease",
+                ],
             }
         ),
     }

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -418,6 +418,7 @@ def test_idx2text(ner_annotations, dataset, annotator, etype, texts):
             {"a": "c"},
             {"a": [4, 1, 4], "b": [3, 1, 1], "d": [0, 1, 0]},
         ),
+        ("sample_nested", "entity", {"a": "z"}, {"a": [1, 1, 2]}),
     ],
 )
 def test_ner_report(ner_annotations, dataset, mode, etypes_map, dict_tp_fn_fp):

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -28,6 +28,7 @@ import spacy
 
 from bluesearch.mining import annotations2df, spacy2df
 from bluesearch.mining.eval import (
+    _check_consistent_iob,
     idx2text,
     iob2idx,
     ner_confusion_matrix,
@@ -600,3 +601,38 @@ def test_ner_errors(ner_annotations, dataset, mode, errors_expected):
 def test_remove_punctuation(punctuation_annotations):
     df_after = remove_punctuation(punctuation_annotations["before"])
     pd.testing.assert_frame_equal(df_after, punctuation_annotations["after"])
+
+
+@pytest.mark.parametrize(
+    "iob_pred, raises",
+    [
+        (pd.Series(["O", "B-a", "B-a", "I-a", "B-c", "O"]), False),
+        (
+            pd.Series(["O", "B-a", "B-a", "I-a", "B-c"]),
+            "inconsistent numbers",
+        ),
+        (
+            pd.Series(["O", "blah", "B-a", "I-a", "B-c", "O"]),
+            "label must be one of",
+        ),
+        (
+            pd.Series(["O", "B-a", "B-a", "I-a", "I-c", "O"]),
+            "should follow one of",
+        ),
+        (
+            pd.Series(["I-a", "B-a", "B-a", "I-a", "I-a", "O"]),
+            "should follow one of",
+        ),
+        (
+            pd.Series(["O", "B-a", "B-a", "I-a", "O", "I-a"]),
+            "should follow one of",
+        ),
+    ],
+)
+def test_check_consistent_iob(iob_pred, raises):
+    iob_true = pd.Series(["B-a", "O", "B-a", "I-a", "I-a", "B-a"])
+    if not raises:
+        assert _check_consistent_iob(iob_true, iob_pred) is None
+    else:
+        with pytest.raises(ValueError, match=fr".*{raises}.*"):
+            _check_consistent_iob(iob_true, iob_pred)

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -632,7 +632,7 @@ def test_remove_punctuation(punctuation_annotations):
 def test_check_consistent_iob(iob_pred, raises):
     iob_true = pd.Series(["B-a", "O", "B-a", "I-a", "I-a", "B-a"])
     if not raises:
-        assert _check_consistent_iob(iob_true, iob_pred) is None
+        _check_consistent_iob(iob_true, iob_pred)
     else:
         with pytest.raises(ValueError, match=fr".*{raises}.*"):
             _check_consistent_iob(iob_true, iob_pred)

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -576,7 +576,7 @@ def test_ner_confusion_matrix(ner_annotations, dataset, mode, cm_vals):
                     "a",
                     {
                         "false_neg": ["Sars Cov-2 infection"],
-                        "false_pos": ["Sars", "Cov-2 infection", "disease"],
+                        "false_pos": ["Cov-2 infection", "Sars", "disease"],
                     },
                 )
             ],

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -418,7 +418,8 @@ def test_idx2text(ner_annotations, dataset, annotator, etype, texts):
             {"a": "c"},
             {"a": [4, 1, 4], "b": [3, 1, 1], "d": [0, 1, 0]},
         ),
-        ("sample_nested", "entity", {"a": "z"}, {"a": [1, 1, 2]}),
+        ("sample_nested", "entity", {"a": "a"}, {"a": [1, 1, 3]}),
+        ("sample_nested", "token", {"a": "a"}, {"a": [4, 0, 1]}),
     ],
 )
 def test_ner_report(ner_annotations, dataset, mode, etypes_map, dict_tp_fn_fp):
@@ -488,6 +489,8 @@ def test_ner_report(ner_annotations, dataset, mode, etypes_map, dict_tp_fn_fp):
         ),
         ("sample", "token", [[0, 4, 1], [3, 1, 0], [0, 1, 0], [1, 2, 1]]),
         ("sample", "entity", [[0, 2, 2], [1, 0, 2], [0, 1, 0], [1, 3, 0]]),
+        ("sample_nested", "token", [[4, 0], [1, 2]]),
+        ("sample_nested", "entity", [[1, 1], [3, 0]]),
     ],
 )
 def test_ner_confusion_matrix(ner_annotations, dataset, mode, cm_vals):
@@ -558,6 +561,24 @@ def test_ner_confusion_matrix(ner_annotations, dataset, mode, cm_vals):
                 ),
                 ("ORGANISM", {"false_neg": [], "false_pos": ["children", "children"]}),
                 ("PATHWAY", {"false_neg": ["infection rate"], "false_pos": []}),
+            ],
+        ),
+        (
+            "sample_nested",
+            "token",
+            [("a", {"false_neg": [], "false_pos": ["disease"]})],
+        ),
+        (
+            "sample_nested",
+            "entity",
+            [
+                (
+                    "a",
+                    {
+                        "false_neg": ["Sars Cov-2 infection"],
+                        "false_pos": ["Sars", "Cov-2 infection", "disease"],
+                    },
+                )
             ],
         ),
     ],

--- a/tests/test_mining/test_eval.py
+++ b/tests/test_mining/test_eval.py
@@ -609,7 +609,7 @@ def test_remove_punctuation(punctuation_annotations):
         (pd.Series(["O", "B-a", "B-a", "I-a", "B-c", "O"]), False),
         (
             pd.Series(["O", "B-a", "B-a", "I-a", "B-c"]),
-            "inconsistent numbers",
+            "target variables with inconsistent numbers of samples",
         ),
         (
             pd.Series(["O", "blah", "B-a", "I-a", "B-c", "O"]),


### PR DESCRIPTION
Fixes #336.

## Description

This PR fixes bugs in our NER evaluation functions of `bluesearch.mining.eval`.
These discrepancies were first identified [here](https://github.com/BlueBrain/Search/issues/336#issuecomment-826830138) and [here](https://github.com/BlueBrain/Search/issues/336#issuecomment-823244116).

## How to test?

Unit tests were added to introduce cases that used to fail and are now passing.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] All CI tests pass. 
- [x] Add more docs on `IOB2` and meaning of `TP`, `FN`, `FP` errors.
- [x] Add informative error when `pred` or `true` is inconsistent + add utils to convert to `IOB2`
- [x] Add type annotations.