### PR TITLE
Patch torch.save() to ensure deterministic behavior

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ import pandas as pd
 import pytest
 import spacy
 import sqlalchemy
+import torch
 from sqlalchemy.exc import OperationalError
 
 import docker
-import torch
 
 torch.manual_seed(42)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,12 +26,9 @@ import pandas as pd
 import pytest
 import spacy
 import sqlalchemy
-import torch
 from sqlalchemy.exc import OperationalError
 
 import docker
-
-torch.manual_seed(42)
 
 ROOT_PATH = Path(__file__).resolve().parent.parent  # root of the repository
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,9 @@ import sqlalchemy
 from sqlalchemy.exc import OperationalError
 
 import docker
+import torch
+
+torch.manual_seed(42)
 
 ROOT_PATH = Path(__file__).resolve().parent.parent  # root of the repository
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -391,16 +391,27 @@ def test_load_spacy_model(model_name, is_found):
 
 
 @pytest.mark.parametrize(
-    "obj,md5_expected",
+    "get_obj,md5_expected",
     [
-        (torch.tensor([8.0, 8.0, 5.0]), "5546f2fd52641b885a6c1ea15863e3b5"),
+        (lambda: torch.tensor([8.0, 8.0, 5.0]), "5546f2fd52641b885a6c1ea15863e3b5"),
         (
-            Sequential(Linear(3, 5), Linear(5, 2)),
+            lambda: {
+                "a": torch.tensor([8.0, 8.0, 5.0]),
+                "b": torch.tensor([3.0, 1.0, 2.0, 4.0]),
+                "c": torch.tensor([[1.0, 1.9], [1.2, 1.3]]),
+            },
+            "9ececc40bc9a3106c24752db8f77bf7a",
+        ),
+        (
+            lambda: Sequential(Linear(3, 5), Linear(5, 2)),
             "f6b79c070f2713f64af77cce3e9e2536",
         ),
     ],
 )
-def test_patched_torch_save(tmpdir, obj, md5_expected):
+def test_patched_torch_save(tmpdir, get_obj, md5_expected):
+    torch.manual_seed(42)
+    obj = get_obj()
+
     file_out = pathlib.Path(str(tmpdir)) / "output.pt"
 
     with patch("torch.serialization._save", patched_torch_save):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -391,19 +391,28 @@ def test_load_spacy_model(model_name, is_found):
 
 
 @pytest.mark.parametrize(
-    "get_obj",
+    "get_obj,md5_expected",
     [
-        lambda: torch.tensor([8.0, 8.0, 5.0]),
-        lambda: {
-            "a": torch.tensor([8.0, 8.0, 5.0]),
-            "b": torch.tensor([3.0, 1.0, 2.0, 4.0]),
-            "c": torch.tensor([[1.0, 1.9], [1.2, 1.3]]),
-        },
-        lambda: Sequential(Linear(3, 5), Linear(5, 2)),
-        lambda: Sequential(Linear(3, 5), Linear(5, 2)).state_dict(),
+        (lambda: torch.tensor([8.0, 8.0, 5.0]), "7ed7d6525b5565778d8f27b4ca122d09"),
+        (
+            lambda: {
+                "a": torch.tensor([8.0, 8.0, 5.0]),
+                "b": torch.tensor([3.0, 1.0, 2.0, 4.0]),
+                "c": torch.tensor([[1.0, 1.9], [1.2, 1.3]]),
+            },
+            "9ececc40bc9a3106c24752db8f77bf7a",
+        ),
+        (
+            lambda: Sequential(Linear(3, 5), Linear(5, 2)),
+            "f6b79c070f2713f64af77cce3e9e2536",
+        ),
+        (
+            lambda: Sequential(Linear(3, 5), Linear(5, 2)).state_dict(),
+            "55a309ec6a538c08b8a30862f5bf44cd",
+        ),
     ],
 )
-def test_patched_torch_save(tmpdir, get_obj):
+def test_patched_torch_save(tmpdir, get_obj, md5_expected):
     file_out = pathlib.Path(str(tmpdir)) / "output.pt"
     md5_sums = []
 
@@ -418,4 +427,4 @@ def test_patched_torch_save(tmpdir, get_obj):
             data = f.read()
             md5_sums.append(hashlib.md5(data).hexdigest())
 
-    assert md5_sums[0] == md5_sums[1]
+    assert md5_sums[0] == md5_sums[1] == md5_expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -400,6 +400,7 @@ def test_load_spacy_model(model_name, is_found):
             "c": torch.tensor([[1.0, 1.9], [1.2, 1.3]]),
         },
         lambda: Sequential(Linear(3, 5), Linear(5, 2)),
+        lambda: Sequential(Linear(3, 5), Linear(5, 2)).state_dict(),
     ],
 )
 def test_patched_torch_save(tmpdir, get_obj):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -403,13 +403,12 @@ def test_load_spacy_model(model_name, is_found):
     ],
 )
 def test_patched_torch_save(tmpdir, get_obj):
+    file_out = pathlib.Path(str(tmpdir)) / "output.pt"
     md5_sums = []
 
     for _ in range(2):
         torch.manual_seed(42)
         obj = get_obj()
-
-        file_out = pathlib.Path(str(tmpdir)) / "output.pt"
 
         with patch("torch.serialization._save", patched_torch_save):
             torch.save(obj, file_out)


### PR DESCRIPTION
Fixes #343.

## Description

We have observed that `torch.save()` produces non-deterministic binary outputs. This PR introduces a patch to fix that.

The idea of this patch is to simply map the non-deterministic `_cdata` attributes to a deterministic value using a dictionary that is incrementally populated. For more details, see section `📌 Content of this PR` in https://github.com/pytorch/pytorch/pull/57536.

**Note**. This PR was also opened on `pytorch` GitHub https://github.com/pytorch/pytorch/pull/57536, but while waiting for that PR to be merged and a new version of `torch` to be released, we need something on our side to be able to move on (especially with #351).


## How to test?

Wrap your calls to `torch.save()` in the following way to ensure deterministic outputs.
```python
from unittest.mock import patch

with patch("torch.serialization._save", patched_torch_save):
    torch.save(obj, out_file)
```

See also examples in section `🧪 How to test` in https://github.com/pytorch/pytorch/pull/57536.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
