### PR TITLE
Fix NER eval bug — dtype conversion from NumPy's to Python's

### DIFF
--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -306,10 +306,10 @@ def unique_etypes(iob, return_counts=False, mode="entity"):
         return unique
     else:
         if mode == "entity":
-            unique_counts = [(iob == f"B-{etype}").sum() for etype in unique]
+            unique_counts = [(iob == f"B-{etype}").sum().item() for etype in unique]
         elif mode == "token":
             unique_counts = [
-                (iob.isin([f"B-{etype}", f"I-{etype}"])).sum() for etype in unique
+                (iob.isin([f"B-{etype}", f"I-{etype}"])).sum().item() for etype in unique
             ]
         else:
             raise ValueError(f"Mode '{mode}' is not available.")
@@ -443,9 +443,9 @@ def ner_report(
             ent_pred = iob_pred.isin(
                 [f"B-{etypes_map[etype]}", f"I-{etypes_map[etype]}"]
             )
-            n_true = ent_true.sum()
-            n_pred = ent_pred.sum()
-            true_pos = (ent_true & ent_pred).sum()
+            n_true = ent_true.sum().item()
+            n_pred = ent_pred.sum().item()
+            true_pos = (ent_true & ent_pred).sum().item()
         else:
             raise ValueError(f"Mode {mode} is not available.")
 

--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -309,7 +309,8 @@ def unique_etypes(iob, return_counts=False, mode="entity"):
             unique_counts = [(iob == f"B-{etype}").sum().item() for etype in unique]
         elif mode == "token":
             unique_counts = [
-                (iob.isin([f"B-{etype}", f"I-{etype}"])).sum().item() for etype in unique
+                (iob.isin([f"B-{etype}", f"I-{etype}"])).sum().item()
+                for etype in unique
             ]
         else:
             raise ValueError(f"Mode '{mode}' is not available.")


### PR DESCRIPTION
Fixes #361.

## Description

The isssue was due to the fact that the returned values of `ner_report` were the result of a reduce operation (`.sum()` in this case) on a `pd.Series` of integers. And integers are represented by `np.int64` in `pandas`, rather than the native `int` type of Python.

Two possible solutions (see also [here](https://stackoverflow.com/questions/9452775/converting-numpy-dtypes-to-native-python-types)).
1. Manually cast to desired type, e.g. `int(series.sum())`
2. Extract the underlying value as a Python scalar with [`.item()`](https://pandas.pydata.org/docs/reference/api/pandas.Series.item.html), e.g. `series.sum().item()`

I think option 2 is better, since it's more generic: `np.float32` will be automatically converted to `float`, `np.int64` to `int` etc. So I used this approach.


## How to test?

The test example given in #361 should now run without error.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] All CI tests pass. 
