### PR TITLE
Add new linting components

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -47,6 +47,7 @@ Latest
   :code:`ner_confusion_matrix` functions from :code:`bluesearch.mining.eval` submodule.
 - |Add| utility function :code:`_check_consistent_iob` inside
   :code:`bluesearch.mining.eval`.
+- |Change| upgrade linting tools in ``tox.ini``
 
 
 Version 0.1.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
-
+"""The setup script."""
 import os
 
 from setuptools import find_packages, setup
@@ -24,10 +24,10 @@ DESCRIPTION = (
 )
 
 LONG_DESCRIPTION = """
-Blue Brain Search is a text mining toolbox to perform semantic literature search 
+Blue Brain Search is a text mining toolbox to perform semantic literature search
 and structured information extraction from text sources.
 
-This project originated from the Blue Brain Project efforts on exploring and 
+This project originated from the Blue Brain Project efforts on exploring and
 mining the CORD-19 dataset."""
 
 CLASSIFIERS = [

--- a/src/bluesearch/database/mining_cache.py
+++ b/src/bluesearch/database/mining_cache.py
@@ -307,7 +307,7 @@ class CreateMiningCache:
 
     def _delete_rows(self):
         """Delete rows in the target table that will be re-populated."""
-        for model_id, model_schema in self.model_schemas.items():
+        for model_id, _model_schema in self.model_schemas.items():
             # Reformatted due to this bandit bug in python3.8:
             # https://github.com/PyCQA/bandit/issues/658
             query = (  # nosec
@@ -576,7 +576,7 @@ class CreateMiningCache:
         schema_df = self.ee_models_library
 
         model_schemas: Dict[str, Dict[str, Any]] = {}
-        for i, row in schema_df.iterrows():
+        for _i, row in schema_df.iterrows():
             entity_type_to = row["entity_type"]
             model_path = row["model_path"]
             model_id = row["model_id"]

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -272,8 +272,8 @@ def compute_database_embeddings(connection, model, indices, batch_size=10):
     sentences = retrieve_sentences_from_sentence_ids(indices, connection)
     n_sentences = len(sentences)
 
-    all_embeddings = list()
-    all_ids = list()
+    all_embeddings = []
+    all_ids = []
 
     for batch_ix in range((n_sentences // batch_size) + 1):
         start_ix = batch_ix * batch_size

--- a/src/bluesearch/mining/entity.py
+++ b/src/bluesearch/mining/entity.py
@@ -19,7 +19,6 @@
 
 import ast
 import copy
-from typing import cast
 
 import numpy as np
 import pandas as pd
@@ -180,14 +179,7 @@ class PatternCreator:
             If ``int`` then represent a row index to be dropped. If ``list`` then
             a collection of row indices to be dropped.
         """
-        # Both DataFrame.drop() and DataFrame.reset_index() return None if
-        # the parameter inplace=True is set. We have inplace=False but need to
-        # cast the returned object from Optional[DataFrame] to DataFrame in
-        # order to satisfy mypy.
-        # There is a big discussion on deprecating the inplace parameter here:
-        # https://github.com/pandas-dev/pandas/issues/16529
-        self._storage = cast(pd.DataFrame, self._storage.drop(index=labels))
-        self._storage = cast(pd.DataFrame, self._storage.reset_index(drop=True))
+        self._storage = self._storage.drop(index=labels).reset_index(drop=True)
 
     def to_df(self):
         """Convert to a pd.DataFrame.

--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -22,7 +22,7 @@ import json
 import string
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -78,8 +78,7 @@ def _check_consistent_iob(iob_true: pd.Series, iob_pred: pd.Series) -> None:
             )
 
         etypes = unique_etypes(x)
-        # cast() needed to tell mypy that fillna() doesn't return None here.
-        x_prev = cast(pd.Series, x.shift(periods=1).fillna("O", inplace=False))
+        x_prev = x.shift(periods=1).fillna("O", inplace=False)
         for etype in etypes:
             if (
                 x.isin([f"I-{etype}"]) & ~x_prev.isin([f"B-{etype}", f"I-{etype}"])

--- a/src/bluesearch/server/embedding_server.py
+++ b/src/bluesearch/server/embedding_server.py
@@ -192,7 +192,7 @@ class EmbeddingServer(Flask):
     @staticmethod
     def make_json_response(embedding):
         """Generate a json response."""
-        json_response = dict(embedding=[float(n) for n in embedding])
+        json_response = {"embedding": [float(n) for n in embedding]}
         response = jsonify(json_response)
 
         return response

--- a/src/bluesearch/server/search_server.py
+++ b/src/bluesearch/server/search_server.py
@@ -219,14 +219,18 @@ class SearchServer(Flask):
 
             self.logger.info(f"Search completed, got {len(sentence_ids)} results.")
 
-            response = dict(
-                sentence_ids=sentence_ids.tolist(),
-                similarities=similarities.tolist(),
-                stats=stats,
-            )
+            response = {
+                "sentence_ids": sentence_ids.tolist(),
+                "similarities": similarities.tolist(),
+                "stats": stats,
+            }
         else:
             self.logger.info("Search query is not JSON. Not processing.")
-            response = dict(sentence_ids=None, similarities=None, stats=None)
+            response = {
+                "sentence_ids": None,
+                "similarities": None,
+                "stats": None,
+            }
 
         response_json = jsonify(response)
 

--- a/src/bluesearch/widgets/article_saver.py
+++ b/src/bluesearch/widgets/article_saver.py
@@ -170,16 +170,16 @@ class ArticleSaver:
         just_paragraphs : set of tuple
             Set of tuple (article_id, paragraph_pos_in_article) chosen by the user.
         """
-        full_articles = set(
+        full_articles = {
             article_id
             for article_id, paragraph_pos_in_article in self.state
             if paragraph_pos_in_article == -1
-        )
-        just_paragraphs = set(
+        }
+        just_paragraphs = {
             (article_id, paragraph_pos_in_article)
             for article_id, paragraph_pos_in_article in self.state
             if paragraph_pos_in_article != -1 and article_id not in full_articles
-        )
+        }
         return full_articles, just_paragraphs
 
     def get_saved_items(self):

--- a/src/bluesearch/widgets/mining_schema.py
+++ b/src/bluesearch/widgets/mining_schema.py
@@ -18,7 +18,6 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import warnings
-from typing import cast
 
 import pandas as pd
 
@@ -69,19 +68,13 @@ class MiningSchema:
             "ontology_source": ontology_source,
         }
         # Make sure there are no duplicates to begin with
-        # cast() to tell mypy that drop_duplicates() doesn't return None here.
-        self.schema_df = cast(
-            pd.DataFrame, self.schema_df.drop_duplicates(ignore_index=True)
-        )
+        self.schema_df = self.schema_df.drop_duplicates(ignore_index=True)
         # 'row' has type Dict[str, Any]. It is valid for append(). Ignoring the error.
         self.schema_df = self.schema_df.append(row, ignore_index=True)  # type: ignore[arg-type]  # noqa
         # If there are any duplicates at this point, then it must have
         # come from the appended row.
         if any(self.schema_df.duplicated()):
-            # cast() to tell mypy that drop_duplicates() doesn't return None here.
-            self.schema_df = cast(
-                pd.DataFrame, self.schema_df.drop_duplicates(ignore_index=True)
-            )
+            self.schema_df = self.schema_df.drop_duplicates(ignore_index=True)
             warnings.warn("This entry already exists. No new entry was created.")
 
     def add_from_df(self, entity_df):

--- a/src/bluesearch/widgets/search_widget.py
+++ b/src/bluesearch/widgets/search_widget.py
@@ -758,7 +758,7 @@ class SearchWidget(widgets.VBox):
         rows = []
         columns = ["Article ID", "Paragraph #", "Paragraph", "Article", "Title"]
         markers = {True: "✓", False: ""}
-        for article_id, paragraph_pos, sentence_id in self.history:
+        for article_id, paragraph_pos, _sentence_id in self.history:
             # Get saving status from the article saver
             if self.article_saver is None:
                 paragraph_saved = False
@@ -812,7 +812,7 @@ class SearchWidget(widgets.VBox):
     def _update_page_display(self):
         with self.widgets["out"]:
             print_whole_paragraph = self.widgets["print_paragraph"].value
-            self.radio_buttons = list()
+            self.radio_buttons = []
 
             self.widgets["out"].clear_output()
             start = self.current_page * self.results_per_page

--- a/tests/test_database/test_cord_19.py
+++ b/tests/test_database/test_cord_19.py
@@ -99,7 +99,7 @@ class TestDatabaseCreation:
     def test_database_content(self, real_sqlalchemy_engine):
         """Tests that the two tables expected has been created. """
         inspector = sqlalchemy.inspect(real_sqlalchemy_engine)
-        tables_names = [table_name for table_name in inspector.get_table_names()]
+        tables_names = list(inspector.get_table_names())
         assert "sentences" in tables_names
         assert "articles" in tables_names
 
@@ -228,12 +228,8 @@ class TestDatabaseCreation:
         Tests that the schema of the fake database is always the same as
         the real one.
         """
-        real_tables_names = {
-            table_name for table_name in real_sqlalchemy_engine.table_names()
-        }
-        fake_tables_names = {
-            table_name for table_name in fake_sqlalchemy_engine.table_names()
-        }
+        real_tables_names = set(real_sqlalchemy_engine.table_names())
+        fake_tables_names = set(fake_sqlalchemy_engine.table_names())
 
         assert real_tables_names == {"articles", "sentences"}
         assert real_tables_names.issubset(fake_tables_names)

--- a/tests/test_database/test_cord_19.py
+++ b/tests/test_database/test_cord_19.py
@@ -97,7 +97,7 @@ class TestDatabaseCreation:
     """Tests the creation of the Database"""
 
     def test_database_content(self, real_sqlalchemy_engine):
-        """Tests that the two tables expected has been created. """
+        """Tests that the two tables expected has been created."""
         inspector = sqlalchemy.inspect(real_sqlalchemy_engine)
         tables_names = list(inspector.get_table_names())
         assert "sentences" in tables_names

--- a/tests/test_database/test_mining_cache.py
+++ b/tests/test_database/test_mining_cache.py
@@ -161,7 +161,7 @@ class TestMiner:
         miner, _, _ = miner_env
         miner.clean_up()
 
-        for logger_name, level, text in caplog.record_tuples:
+        for logger_name, level, _text in caplog.record_tuples:
             assert logger_name == str(miner)
             assert level == logging.INFO
 

--- a/tests/test_mining/test_attribute.py
+++ b/tests/test_mining/test_attribute.py
@@ -1116,7 +1116,7 @@ class TestAttributeExtraction:
         df = extractor.extract_attributes(text, raw_attributes=True)
         assert isinstance(df, pd.DataFrame)
         assert len(df) == 0
-        assert set(["attribute"]).issubset(set(df.columns))
+        assert {"attribute"}.issubset(set(df.columns))
 
 
 class TestAttributeAnnotationTab:

--- a/tests/test_server/test_mining_server.py
+++ b/tests/test_server/test_mining_server.py
@@ -171,7 +171,7 @@ class TestMiningServer:
         identifiers = [(1, 0), (2, -1), (3, 1)]
 
         expected_length = 0
-        for article_id, pos in identifiers:
+        for _article_id, pos in identifiers:
             n_paragraphs = test_parameters["n_sections_per_article"] if pos == -1 else 1
             expected_length += test_parameters["n_entities_per_section"] * n_paragraphs
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -191,7 +191,7 @@ class TestSQLQueries:
             * test_parameters["n_sentences_per_section"]
         )
         assert len(article_ids_dict) == num_sentences
-        article_ids = [x for x in article_ids_dict.values()]
+        article_ids = list(article_ids_dict.values())
         assert len(set(article_ids)) == test_parameters["n_articles"]
 
 

--- a/tests/test_widgets/test_article_saver.py
+++ b/tests/test_widgets/test_article_saver.py
@@ -65,7 +65,7 @@ class TestArticleSaver:
             assert not article_saver.has_paragraph(article_id, paragraph_id)
 
     def test_summaries(self, fake_sqlalchemy_engine, tmpdir):
-        """Test that article_saver is good. """
+        """Test that article_saver is good."""
 
         article_saver = ArticleSaver(connection=fake_sqlalchemy_engine)
 

--- a/tests/test_widgets/test_article_saver.py
+++ b/tests/test_widgets/test_article_saver.py
@@ -86,10 +86,9 @@ class TestArticleSaver:
             all_paragraph_pos_in_article = pd.read_sql(
                 sql_query, fake_sqlalchemy_engine
             )["paragraph_pos_in_article"].to_list()
-            all_articles_paragraphs_id[article_id] = [
-                paragraph_pos_in_article
-                for paragraph_pos_in_article in set(all_paragraph_pos_in_article)
-            ]
+            all_articles_paragraphs_id[article_id] = list(
+                set(all_paragraph_pos_in_article)
+            )
             # For all articles extract only the first of their paragraphs
             paragraph_pos_in_article = all_articles_paragraphs_id[article_id][0]
             article_saver.add_paragraph(article_id, paragraph_pos_in_article)

--- a/tests/test_widgets/test_mining_schema.py
+++ b/tests/test_widgets/test_mining_schema.py
@@ -61,7 +61,7 @@ def test_df(mining_schema_df):
 
     # Test ignoring unknown columns
     schema_df_new = mining_schema_df.drop_duplicates().copy()
-    schema_df_new["unknown_column"] = [i for i in range(len(schema_df_new))]
+    schema_df_new["unknown_column"] = list(range(len(schema_df_new)))
     mining_schema = MiningSchema()
     with pytest.warns(UserWarning, match=r"column.* unknown_column"):
         mining_schema.add_from_df(schema_df_new)

--- a/tests/test_widgets/test_search_widget.py
+++ b/tests/test_widgets/test_search_widget.py
@@ -404,7 +404,7 @@ def test_article_saver_gets_updated(
 
 
 def test_errors(fake_sqlalchemy_engine, monkeypatch, capsys):
-    """Check that widget raises an error when bbs search server not working. """
+    """Check that widget raises an error when bbs search server not working."""
 
     with pytest.raises(Exception):
         SearchWidget(

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@
 [tox]
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
-source = src/bluesearch
+sources = setup.py src/bluesearch tests benchmarks
 envlist =
     lint
     py37
@@ -49,12 +49,11 @@ deps =
     pandas-stubs==1.1.0.6
     sqlalchemy-stubs==0.4
 commands =
-    flake8 {[tox]source} tests benchmarks
-    isort --check setup.py {[tox]source} tests benchmarks
-    black -q --check setup.py {[tox]source} tests benchmarks
-    bandit -qr {[tox]source}
-    mypy --config-file .mypy.ini  setup.py {[tox]source} tests
-    mypy --config-file .mypy.ini  {[tox]source} benchmarks
+    flake8 {posargs:{[tox]sources}}
+    isort --check {posargs:{[tox]sources}}
+    black -q --check {posargs:{[tox]sources}}
+    bandit -qr --exclude "benchmarks/,tests/" {posargs:{[tox]sources}}
+    mypy --config-file .mypy.ini --exclude "benchmarks/conftest.py" {posargs:{[tox]sources}}
 
 [testenv:format]
 basepython = python3.7
@@ -63,8 +62,8 @@ deps =
     black==21.5b1
     isort==5.8.0
 commands =
-    isort setup.py {[tox]source} tests benchmarks
-    black setup.py {[tox]source} tests benchmarks
+    isort {posargs:{[tox]sources}}
+    black {posargs:{[tox]sources}}
 
 [testenv:docs]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -40,16 +40,17 @@ skip_install = true
 deps =
     bandit==1.7.0
     black==20.8b1
-    flake8==3.8.4
+    flake8==3.9.2
+    flake8-bugbear==21.4.3
+    flake8-comprehensions==3.5.0
+    flake8-docstrings==1.6.0
     isort==5.7.0
-    pydocstyle==5.1.1
     mypy==0.812
     pandas-stubs==1.0.4.5
     sqlalchemy-stubs==0.4
 commands =
     flake8 {[tox]source} tests benchmarks
     isort --check setup.py {[tox]source} tests benchmarks
-    pydocstyle {[tox]source}
     black -q --check setup.py {[tox]source} tests benchmarks
     bandit -qr {[tox]source}
     mypy --config-file .mypy.ini  setup.py {[tox]source} tests
@@ -141,9 +142,10 @@ show_missing = False
 count = False
 max-line-length = 88
 extend-ignore = E203
-
-[pydocstyle]
-convention = numpy
+docstring-convention = numpy
+per-file-ignores =
+    tests/*:D
+    benchmarks/*:D
 
 [isort]
 profile = black

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ deps =
     flake8-docstrings==1.6.0
     isort==5.8.0
     mypy==0.812
-    pandas-stubs==1.0.4.5
+    pandas-stubs==1.1.0.6
     sqlalchemy-stubs==0.4
 commands =
     flake8 {[tox]source} tests benchmarks

--- a/tox.ini
+++ b/tox.ini
@@ -39,12 +39,12 @@ basepython = python3.7
 skip_install = true
 deps =
     bandit==1.7.0
-    black==20.8b1
+    black==21.5b1
     flake8==3.9.2
     flake8-bugbear==21.4.3
     flake8-comprehensions==3.5.0
     flake8-docstrings==1.6.0
-    isort==5.7.0
+    isort==5.8.0
     mypy==0.812
     pandas-stubs==1.0.4.5
     sqlalchemy-stubs==0.4
@@ -60,8 +60,8 @@ commands =
 basepython = python3.7
 skip_install = true
 deps =
-    black==20.8b1
-    isort==5.7.0
+    black==21.5b1
+    isort==5.8.0
 commands =
     isort setup.py {[tox]source} tests benchmarks
     black setup.py {[tox]source} tests benchmarks

--- a/tox.ini
+++ b/tox.ini
@@ -19,13 +19,7 @@
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
 sources = setup.py src/bluesearch tests benchmarks
-envlist =
-    lint
-    py37
-    py38
-    py39
-    docs
-    check-packaging
+envlist = lint, py{37, 38, 39}, docs, check-packaging
 
 [testenv]
 download = true
@@ -53,7 +47,7 @@ commands =
     isort --check {posargs:{[tox]sources}}
     black -q --check {posargs:{[tox]sources}}
     bandit -qr --exclude "benchmarks/,tests/" {posargs:{[tox]sources}}
-    mypy --config-file .mypy.ini --exclude "benchmarks/conftest.py" {posargs:{[tox]sources}}
+    mypy --exclude "benchmarks/conftest.py" {posargs:{[tox]sources}}
 
 [testenv:format]
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ deps =
     sqlalchemy-stubs==0.4
 commands =
     flake8 {[tox]source} tests benchmarks
-    isort --honor-noqa --profile black --check setup.py {[tox]source} tests benchmarks
+    isort --check setup.py {[tox]source} tests benchmarks
     pydocstyle {[tox]source}
     black -q --check setup.py {[tox]source} tests benchmarks
     bandit -qr {[tox]source}
@@ -62,7 +62,7 @@ deps =
     black==20.8b1
     isort==5.7.0
 commands =
-    isort --honor-noqa --profile=black setup.py {[tox]source} tests benchmarks
+    isort setup.py {[tox]source} tests benchmarks
     black setup.py {[tox]source} tests benchmarks
 
 [testenv:docs]
@@ -144,3 +144,7 @@ extend-ignore = E203
 
 [pydocstyle]
 convention = numpy
+
+[isort]
+profile = black
+honor_noqa = true

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ deps =
 commands =
     flake8 {posargs:{[tox]sources}}
     isort --check {posargs:{[tox]sources}}
-    black -q --check {posargs:{[tox]sources}}
+    black --check {posargs:{[tox]sources}}
     bandit -qr --exclude "benchmarks/,tests/" {posargs:{[tox]sources}}
     mypy --exclude "benchmarks/conftest.py" {posargs:{[tox]sources}}
 


### PR DESCRIPTION
Closes #363 .

## Description

- Add `flake8-bugbear`, `flake8-comprehensions`, and `flake8-docstrings` to the linting pipeline
- Add `isort` configuration to `tox.ini` (instead of providing configuration on the command line)
- Upgrade `black` and `isort`
- Upgrade `pandas-stubs`, this makes the artificial casting to `pd.DataFrame` that we introduced obsolete.
- Streamline the command line parameters in the `lint` and `format` tox sections
- Add possibility to provide files for linting and formatting as positional arguments to tox.

## How to test?

The main changes are in `tox.ini`, all other changes are fixes for new linting errors.

The linting should pass:
```bash
$ tox -e lint
```

Furthermore, now it's also possible to lint/format selected paths by providing them as positional arguments to tox:
```bash
$ tox -e format -- custom_path
$ tox -e lint -- custom_path
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 

# Follow-Up Ideas
Should we lint/test the `.py` files in `data_and_models` as well? Right now there's complete anarchy.
