### PR TITLE
Reduce the training time on CPU of Transformer-based NER pipelines

### DIFF
--- a/data_and_models/pipelines/ner/config.cfg
+++ b/data_and_models/pipelines/ner/config.cfg
@@ -85,10 +85,10 @@ seed = ${system.seed}
 gpu_allocator = ${system.gpu_allocator}
 dropout = 0.2
 accumulate_gradient = 1
-patience = 1600
-max_epochs = 0
-max_steps = 20000
-eval_frequency = 200
+patience = 800  # steps, 4 evaluations if every 200
+max_epochs = 500  # epochs, huge value to be investigated
+max_steps = 0  # ignored when 0
+eval_frequency = 200  # if changed, change patience too
 frozen_components =  ["tok2vec", "tagger", "attribute_ruler", "lemmatizer", "parser"]
 before_to_disk = null
 
@@ -118,7 +118,7 @@ L2 = 0.01
 grad_clip = 1.0
 use_averages = false
 eps = 0.00000001
-learn_rate = 0.001
+learn_rate = 0.00005
 
 [training.score_weights]
 tag_acc = null


### PR DESCRIPTION
Fixes #356.

## Description

Training the Transformer-based NER models (see #351) takes too long on CPU (almost a full day).

The training is happening on CPU because of reproducibility issues (see #343).

The goal was to find `when to stop training to reduce its duration` while keeping the accuracy (see issue description).

An experiment was conducted. Its results are summarized in https://github.com/BlueBrain/Search/issues/356#issuecomment-842451358, https://github.com/BlueBrain/Search/issues/356#issuecomment-842452733, and https://github.com/BlueBrain/Search/issues/356#issuecomment-844254751.

This PR adjusts the NER training duration parameters accordingly to the outcome of the experiment.

⚠️ The issue addressed by this PR (#356) is in the same sprint has the issue introducing the point (#351) it fixes.

There is therefore no _How to test?_ section. However, one could checkout #351 and merge the current PR into it.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).