### PR TITLE
Define JSON schema of machine-readable parses

### DIFF
--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -27,8 +27,9 @@ _T = TypeVar("_T", bound="Article")
 class ArticleParser(ABC):
     """An abstract base class for article parsers."""
 
+    @property
     @abstractmethod
-    def get_title(self) -> str:
+    def title(self) -> str:
         """Get the article title.
 
         Returns
@@ -37,8 +38,9 @@ class ArticleParser(ABC):
             The article title.
         """
 
+    @property
     @abstractmethod
-    def get_authors(self) -> Iterable[str]:
+    def authors(self) -> Iterable[str]:
         """Get all author names.
 
         Returns
@@ -47,8 +49,9 @@ class ArticleParser(ABC):
             All authors.
         """
 
+    @property
     @abstractmethod
-    def get_abstract(self) -> Iterable[str]:
+    def abstract(self) -> Iterable[str]:
         """Get a sequence of paragraphs in the article abstract.
 
         Returns
@@ -57,8 +60,9 @@ class ArticleParser(ABC):
             The paragraphs of the article abstract.
         """
 
+    @property
     @abstractmethod
-    def get_paragraphs(self) -> Iterable[Tuple[str, str]]:
+    def paragraphs(self) -> Iterable[Tuple[str, str]]:
         """Get all paragraphs and titles of sections they are part of.
 
         Returns
@@ -98,7 +102,8 @@ class CORD19ArticleParser(ArticleParser):
                 f"{top_level_keys - set(json_file.keys())}"
             )
 
-    def get_title(self) -> str:
+    @property
+    def title(self) -> str:
         """Get the article title.
 
         Returns
@@ -108,7 +113,8 @@ class CORD19ArticleParser(ArticleParser):
         """
         return self.data["metadata"]["title"]
 
-    def get_authors(self) -> Generator[str, None, None]:
+    @property
+    def authors(self) -> Generator[str, None, None]:
         """Get all author names.
 
         Yields
@@ -130,7 +136,8 @@ class CORD19ArticleParser(ArticleParser):
             )
             yield author_str
 
-    def get_abstract(self) -> List[str]:
+    @property
+    def abstract(self) -> List[str]:
         """Get a sequence of paragraphs in the article abstract.
 
         Returns
@@ -143,7 +150,8 @@ class CORD19ArticleParser(ArticleParser):
 
         return [paragraph["text"] for paragraph in self.data["abstract"]]
 
-    def get_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
+    @property
+    def paragraphs(self) -> Generator[Tuple[str, str], None, None]:
         """Get all paragraphs and titles of sections they are part of.
 
         Yields
@@ -182,10 +190,10 @@ class Article:
         parser
             An article parser instance.
         """
-        title = parser.get_title()
-        authors = tuple(parser.get_authors())
-        abstract = tuple(parser.get_abstract())
-        section_paragraphs = tuple(parser.get_paragraphs())
+        title = parser.title
+        authors = tuple(parser.authors)
+        abstract = tuple(parser.abstract)
+        section_paragraphs = tuple(parser.paragraphs)
 
         return cls(title, authors, abstract, section_paragraphs)
 

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -85,16 +85,16 @@ class CORD19ArticleParser(ArticleParser):
         self.data = json_file
 
         # Check top-level keys
+        # the spec also includes "abstract" but it's missing from the PMC parses
         top_level_keys = {
             "paper_id",
             "metadata",
-            "abstract",
             "body_text",
             "bib_entries",
             "ref_entries",
             "back_matter",
         }
-        if set(json_file.keys()) != top_level_keys:
+        if not top_level_keys.issubset(json_file.keys()):
             raise ValueError(
                 "Incomplete JSON file. Missing keys: "
                 f"{top_level_keys - set(json_file.keys())}"
@@ -140,6 +140,9 @@ class CORD19ArticleParser(ArticleParser):
         list of str
             The paragraphs of the article abstract.
         """
+        if "abstract" not in self.data:
+            return []
+
         return [paragraph["text"] for paragraph in self.data["abstract"]]
 
     def iter_paragraphs(self) -> Generator[Tuple[str, str], None, None]:

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -17,7 +17,7 @@
 """Abstraction of scientific article data and related tools."""
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generator, List, Sequence, Tuple, Type, TypeVar
+from typing import Generator, Iterable, List, Sequence, Tuple, Type, TypeVar
 
 # This is for annotating the return value of the Article.parse class method, see
 # https://github.com/python/typing/issues/254#issuecomment-661803922
@@ -38,35 +38,34 @@ class ArticleParser(ABC):
         """
 
     @abstractmethod
-    def iter_authors(self) -> Generator[str, None, None]:
-        """Iterate over all author names.
+    def get_authors(self) -> Iterable[str]:
+        """Get all author names.
 
-        Yields
-        ------
-        str
-            Every author.
+        Returns
+        -------
+        iterable of str
+            All authors.
         """
 
     @abstractmethod
-    def get_abstract(self) -> Sequence[str]:
+    def get_abstract(self) -> Iterable[str]:
         """Get a sequence of paragraphs in the article abstract.
 
         Returns
         -------
-        sequence of str
+        iterable of str
             The paragraphs of the article abstract.
         """
 
     @abstractmethod
-    def iter_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
-        """Iterate over all paragraphs and titles of sections they are part of.
+    def get_paragraphs(self) -> Iterable[Tuple[str, str]]:
+        """Get all paragraphs and titles of sections they are part of.
 
-        Yields
-        ------
-        str
-            The section title.
-        str
-            The paragraph content.
+        Returns
+        -------
+        iterable of (str, str)
+            For each paragraph a tuple with two strings is returned. The first
+            is the section title, the second the paragraph content.
         """
 
 
@@ -109,8 +108,8 @@ class CORD19ArticleParser(ArticleParser):
         """
         return self.data["metadata"]["title"]
 
-    def iter_authors(self) -> Generator[str, None, None]:
-        """Iterate over all author names.
+    def get_authors(self) -> Generator[str, None, None]:
+        """Get all author names.
 
         Yields
         ------
@@ -144,8 +143,8 @@ class CORD19ArticleParser(ArticleParser):
 
         return [paragraph["text"] for paragraph in self.data["abstract"]]
 
-    def iter_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
-        """Iterate over all paragraphs and titles of sections they are part of.
+    def get_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
+        """Get all paragraphs and titles of sections they are part of.
 
         Yields
         ------
@@ -184,9 +183,9 @@ class Article:
             An article parser instance.
         """
         title = parser.get_title()
-        authors = tuple(parser.iter_authors())
-        abstract = parser.get_abstract()
-        section_paragraphs = tuple(parser.iter_paragraphs())
+        authors = tuple(parser.get_authors())
+        abstract = tuple(parser.get_abstract())
+        section_paragraphs = tuple(parser.get_paragraphs())
 
         return cls(title, authors, abstract, section_paragraphs)
 

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -18,7 +18,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Generator, List, Mapping, Sequence, Tuple, Type, TypeVar
+from typing import Dict, Generator, List, Mapping, Sequence, Tuple, Type, TypeVar
 
 # This is for annotating the return value of the Article.parse class method, see
 # https://github.com/python/typing/issues/254#issuecomment-661803922
@@ -39,7 +39,7 @@ class ArticleParser(ABC):
         """
 
     @abstractmethod
-    def iter_authors(self) -> Generator[str, Any, None]:
+    def iter_authors(self) -> Generator[str, None, None]:
         """Iterate over all author names.
 
         Yields
@@ -59,7 +59,7 @@ class ArticleParser(ABC):
         """
 
     @abstractmethod
-    def iter_paragraphs(self) -> Generator[Tuple[str, str], Any, None]:
+    def iter_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
         """Iterate over all paragraphs and titles of sections they are part of.
 
         Yields
@@ -110,7 +110,7 @@ class CORD19ArticleParser(ArticleParser):
         """
         return self.data["metadata"]["title"]
 
-    def iter_authors(self) -> Generator[str, Any, None]:
+    def iter_authors(self) -> Generator[str, None, None]:
         """Iterate over all author names.
 
         Yields
@@ -142,7 +142,7 @@ class CORD19ArticleParser(ArticleParser):
         """
         return [paragraph["text"] for paragraph in self.data["abstract"]]
 
-    def iter_paragraphs(self) -> Generator[Tuple[str, str], Any, None]:
+    def iter_paragraphs(self) -> Generator[Tuple[str, str], None, None]:
         """Iterate over all paragraphs and titles of sections they are part of.
 
         Yields
@@ -208,7 +208,7 @@ class Article:
 
         return cls(title, authors, abstract, sections)
 
-    def iter_paragraphs(self, with_abstract: bool = True) -> Generator[str, Any, None]:
+    def iter_paragraphs(self, with_abstract: bool = True) -> Generator[str, None, None]:
         """Iterate over all paragraphs in the article.
 
         Parameters

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -1,0 +1,246 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Abstraction of scientific article data and related tools."""
+import warnings
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Generator, List, Sequence, Tuple
+
+
+class ArticleParser(ABC):
+    """An abstract base class for article parsers."""
+
+    @abstractmethod
+    def get_title(self) -> str:
+        """Get the article title.
+
+        Returns
+        -------
+        str
+            The article title.
+        """
+
+    @abstractmethod
+    def iter_authors(self) -> Generator[str, Any, None]:
+        """Iterate over all author names.
+
+        Yields
+        ------
+        str
+            Every author.
+        """
+
+    @abstractmethod
+    def get_abstract(self) -> Sequence[str]:
+        """Get a sequence of paragraphs in the article abstract.
+
+        Returns
+        -------
+        sequence of str
+            The paragraphs of the article abstract.
+        """
+
+    @abstractmethod
+    def iter_paragraphs(self) -> Generator[Tuple[str, str], Any, None]:
+        """Iterate over all paragraphs and titles of sections they are part of.
+
+        Yields
+        ------
+        str
+            The section title.
+        str
+            The paragraph content.
+        """
+
+
+class CORD19ArticleParser(ArticleParser):
+    """Parser for CORD-19 JSON files.
+
+    Parameters
+    ----------
+    json_file
+        The contents of a JSON-file from the CORD-19 database.
+    """
+
+    def __init__(self, json_file: dict) -> None:
+        # data is a reference to json_file, so we shouldn't modify its contents
+        self.data = json_file
+
+        # Check top-level keys
+        top_level_keys = {
+            "paper_id",
+            "metadata",
+            "abstract",
+            "body_text",
+            "bib_entries",
+            "ref_entries",
+            "back_matter",
+        }
+        if set(json_file.keys()) != top_level_keys:
+            raise ValueError(
+                "Incomplete JSON file. Missing keys: "
+                f"{top_level_keys - set(json_file.keys())}"
+            )
+
+    def get_title(self) -> str:
+        """Get the article title.
+
+        Returns
+        -------
+        str
+            The article title.
+        """
+        return self.data["metadata"]["title"]
+
+    def iter_authors(self) -> Generator[str, Any, None]:
+        """Iterate over all author names.
+
+        Yields
+        ------
+        str
+            Every author.
+        """
+        for author in self.data["metadata"]["authors"]:
+            author_str = " ".join(
+                filter(
+                    lambda part: part != "",
+                    (
+                        author["first"],
+                        " ".join(author["middle"]),
+                        author["last"],
+                        author["suffix"],
+                    ),
+                )
+            )
+            yield author_str
+
+    def get_abstract(self) -> List[str]:
+        """Get a sequence of paragraphs in the article abstract.
+
+        Returns
+        -------
+        list of str
+            The paragraphs of the article abstract.
+        """
+        return [paragraph["text"] for paragraph in self.data["abstract"]]
+
+    def iter_paragraphs(self) -> Generator[Tuple[str, str], Any, None]:
+        """Iterate over all paragraphs and titles of sections they are part of.
+
+        Yields
+        ------
+        str
+            The section title.
+        str
+            The paragraph content.
+        """
+        for paragraph in self.data["body_text"]:
+            yield paragraph["section"], paragraph["text"]
+
+    def __str__(self):
+        """Get the string representation the the parser instance."""
+        return f'CORD-19 article ID={self.data["paper_id"]}'
+
+
+class Article:
+    """Abstraction of a scientific article and its contents."""
+
+    def __init__(self) -> None:
+        self.title = ""
+        self.authors: List[str] = []
+        self.abstract: List[str] = []
+        # We require py37+ so this dict is guaranteed insertion-ordered.
+        self.sections: Dict[str, List[str]] = {}
+        self.parsed = False
+
+    def parse(self, parser: ArticleParser) -> None:
+        """Parse an article through a parser.
+
+        Parameters
+        ----------
+        parser
+            An article parser instance.
+
+        Warns
+        -----
+        UserWarning
+            If duplicate section titles are encountered. Since the parsing is
+            paragraph-wise duplicate sections are recognized as two non-adjacent
+            blocks of paragraphs with the same title.
+        """
+        if self.parsed:
+            raise RuntimeError("Can only parse the article once")
+        self.title = parser.get_title()
+        self.authors.extend(parser.iter_authors())
+        self.abstract.extend(parser.get_abstract())
+
+        # Collect sections
+        current_section = None
+        for section, paragraph in parser.iter_paragraphs():
+            if section not in self.sections:
+                self.sections[section] = []
+            elif current_section != section:
+                # We've already seen that section title and it was not part of
+                # the current section.
+                warnings.warn(
+                    f"Duplicate section titles found in {parser}. The respective"
+                    "sections will be merged into one."
+                )
+            current_section = section
+            self.sections[section].append(paragraph)
+
+        self.parsed = True
+
+    def iter_paragraphs(self, with_abstract: bool = True) -> Generator[str, Any, None]:
+        """Iterate over all paragraphs in the article.
+
+        Parameters
+        ----------
+        with_abstract : bool
+            If true the abstract paragraphs will be included at the beginning.
+
+        Yields
+        ------
+        str
+            One of the article paragraphs.
+        """
+        if with_abstract:
+            yield from self.abstract
+        for section_paragraphs in self.sections.values():
+            yield from section_paragraphs
+
+    def __str__(self) -> str:
+        """Get a short summary of the article statistics.
+
+        Returns
+        -------
+        str
+            A summary of the article statistics.
+        """
+        info_str = (
+            f'Title    : "{self.title}"\n'
+            f'Authors  : {", ".join(self.authors)}\n'
+            f"Abstract : {len(self.abstract)} paragraph(s), "
+            f"{sum(map(len, self.abstract))} characters\n"
+            f"Sections : {len(self.sections)} section(s) "
+            f"{sum(sum(map(len, section)) for section in self.sections.values())} "
+            f"characters\n"
+        )
+        for section in self.sections:
+            info_str += f"- {section}\n"
+        info_str += f"Total text length : {sum(map(len, self.iter_paragraphs()))}\n"
+
+        return info_str.strip()

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -154,6 +154,9 @@ class CORD19ArticleParser(ArticleParser):
         """
         for paragraph in self.data["body_text"]:
             yield paragraph["section"], paragraph["text"]
+        # We've always included figure/table captions like this
+        for ref_entry in self.data["ref_entries"].values():
+            yield "Caption", ref_entry["text"]
 
     def __str__(self):
         """Get the string representation the the parser instance."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+import json
 import time
 from pathlib import Path
 
@@ -31,6 +32,8 @@ from sqlalchemy.exc import OperationalError
 import docker
 
 ROOT_PATH = Path(__file__).resolve().parent.parent  # root of the repository
+CORD19_SAMPLE_PATH = ROOT_PATH / "tests" / "data" / "cord19_v35"
+CORD19_SAMPLE_ALL_JSON_PATHS = sorted(CORD19_SAMPLE_PATH.rglob("*.json"))
 
 
 @pytest.fixture(scope="session")
@@ -292,16 +295,25 @@ def fake_sqlalchemy_cnxn(fake_sqlalchemy_engine):
 @pytest.fixture(scope="session")
 def jsons_path():
     """Path to a directory where jsons are stored."""
-    jsons_path = ROOT_PATH / "tests" / "data" / "cord19_v35"
+    jsons_path = CORD19_SAMPLE_PATH
     assert jsons_path.exists()
 
     return jsons_path
 
 
+@pytest.fixture(
+    params=CORD19_SAMPLE_ALL_JSON_PATHS,
+    ids=(path.name for path in CORD19_SAMPLE_ALL_JSON_PATHS),
+)
+def real_json_file(request):
+    with request.param.open() as fp:
+        yield json.load(fp)
+
+
 @pytest.fixture(scope="session")
 def metadata_path():
     """Path to metadata.csv."""
-    metadata_path = ROOT_PATH / "tests" / "data" / "cord19_v35" / "metadata.csv"
+    metadata_path = CORD19_SAMPLE_PATH / "metadata.csv"
     assert metadata_path.exists()
 
     return metadata_path

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -58,26 +58,30 @@ def cord19_json_file():
 
 class TestParser(ArticleParser):
     def __init__(self):
-        self.title = "Test Title"
-        self.authors = ("Author 1", "Author 2")
-        self.abstract = ("Abstract paragraph 1", "Abstract paragraph 2")
-        self.paragraphs = [
+        self._title = "Test Title"
+        self._authors = ("Author 1", "Author 2")
+        self._abstract = ("Abstract paragraph 1", "Abstract paragraph 2")
+        self._paragraphs = [
             ("Section 1", "Paragraph 1."),
             ("Section 1", "Paragraph 2."),
             ("Section 2", "Paragraph 1."),
         ]
 
-    def get_title(self):
-        return self.title
+    @property
+    def title(self):
+        return self._title
 
-    def get_authors(self):
-        yield from self.authors
+    @property
+    def authors(self):
+        yield from self._authors
 
-    def get_abstract(self):
-        return self.abstract
+    @property
+    def abstract(self):
+        return self._abstract
 
-    def get_paragraphs(self):
-        yield from self.paragraphs
+    @property
+    def paragraphs(self):
+        yield from self._paragraphs
 
 
 class TestCORD19ArticleParser:
@@ -94,13 +98,13 @@ class TestCORD19ArticleParser:
 
     def test_get_title(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        title = parser.get_title()
+        title = parser.title
         assert title != ""
         assert title == cord19_json_file["metadata"]["title"]
 
     def test_iter_authors(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        authors = tuple(parser.get_authors())
+        authors = tuple(parser.authors)
 
         # Check that all authors have been parsed
         assert len(authors) == len(cord19_json_file["metadata"]["authors"])
@@ -117,7 +121,7 @@ class TestCORD19ArticleParser:
 
     def test_get_abstract(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        abstract = parser.get_abstract()
+        abstract = parser.abstract
 
         # Check that all paragraphs were parsed
         assert len(abstract) == len(cord19_json_file["abstract"])
@@ -129,11 +133,11 @@ class TestCORD19ArticleParser:
         # Check that if "abstract" is missing then an empty list is returned
         del cord19_json_file["abstract"]
         parser = CORD19ArticleParser(cord19_json_file)
-        assert parser.get_abstract() == []
+        assert list(parser.abstract) == []
 
     def test_iter_paragraphs(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        paragraphs = tuple(parser.get_paragraphs())
+        paragraphs = tuple(parser.paragraphs)
 
         # Check that all paragraphs were parsed
         n_body_text = len(cord19_json_file["body_text"])
@@ -162,7 +166,7 @@ class TestArticle:
         parser = TestParser()
         article = Article.parse(parser)
         assert article.title == parser.title
-        assert tuple(article.authors) == parser.authors
+        assert article.authors == tuple(parser.authors)
 
         # Test iterating over all paragraphs in the article. By default the
         # abstract is not included

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -33,13 +33,6 @@ class SimpleTestParser(ArticleParser):
         yield from self._paragraphs
 
 
-# @pytest.fixture(params=sorted(jsons_path().rglob("*.json")))
-# def real_json_file(json_file_path):
-#     with json_file_path.open() as fp:
-#         json_file = json.load(fp)
-#         yield json_file
-
-
 class TestCORD19ArticleParser:
     def test_init(self, real_json_file):
         # Should be able to read real JSON files no problem.

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -165,25 +165,17 @@ class TestArticle:
         assert tuple(article.authors) == parser.authors
 
         # Test iterating over all paragraphs in the article. By default the
-        # abstract is also included
-        paragraph_texts = [text for _section, text in parser.paragraphs]
-        for text, text_want in zip(
-            article.iter_paragraphs(), chain(parser.abstract, paragraph_texts)
-        ):
+        # abstract is not included
+        for text, text_want in zip(article.iter_paragraphs(), parser.paragraphs):
             assert text == text_want
 
-        # Test excluding the paragraphs
+        # This time test with the abstract paragraphs included.
+        abstract_paragraphs = [("Abstract", text) for text in parser.abstract]
         for text, text_want in zip(
-            article.iter_paragraphs(with_abstract=False), paragraph_texts
+            article.iter_paragraphs(with_abstract=True),
+            chain(abstract_paragraphs, parser.paragraphs),
         ):
             assert text == text_want
-
-        # If two duplicate section names are detected then a warning should be
-        # emitted. Add a paragraph from section 1 after section 2 to simulate
-        # this situation
-        parser.paragraphs.append(("Section 1", "Paragraph 3."))
-        with pytest.warns(UserWarning, match=r"(D|d)uplicate"):
-            Article.parse(parser)
 
     def test_str(self):
         parser = TestParser()

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -5,58 +5,7 @@ import pytest
 from bluesearch.database.article import Article, ArticleParser, CORD19ArticleParser
 
 
-@pytest.fixture()
-def cord19_json_file():
-    json_data = {
-        "paper_id": "93140ed88011aaef108208016a0769ad19327dae",
-        "metadata": {
-            "title": "Some Title",
-            "authors": [
-                {"first": "Jane", "middle": [], "last": "Doe", "suffix": "Dr."},
-                {"first": "Erika", "middle": [], "last": "Mustermann", "suffix": ""},
-                {"first": "Jean", "middle": ["X."], "last": "Dupont", "suffix": ""},
-                {
-                    "first": "Titius",
-                    "middle": ["J.", "K."],
-                    "last": "Seius",
-                    "suffix": "Jr.",
-                },
-            ],
-        },
-        "abstract": [
-            {
-                "section": "Abstract",
-                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-            }
-        ],
-        "body_text": [
-            {
-                "section": "Introduction",
-                "text": "Cras non ante a arcu cursus euismod id a odio.",
-            },
-            {
-                "section": "Introduction",
-                "text": "Curabitur eget est vehicula, [...], auctor erat.",
-            },
-            {
-                "section": "Conclusion",
-                "text": "Aliquam sit amet lacus vehicula, [...], eleifend odio.",
-            },
-        ],
-        "bib_entries": {},
-        "ref_entries": {
-            "FIGREF7": {"text": "This figure shows...", "type": "figure"},
-            "TABREF23": {
-                "text": "The results are presented in the table above.",
-                "type": "table",
-            },
-        },
-        "back_matter": [],
-    }
-    return json_data
-
-
-class TestParser(ArticleParser):
+class SimpleTestParser(ArticleParser):
     def __init__(self):
         self._title = "Test Title"
         self._authors = ("Author 1", "Author 2")
@@ -84,86 +33,90 @@ class TestParser(ArticleParser):
         yield from self._paragraphs
 
 
-class TestCORD19ArticleParser:
-    def test_init(self, cord19_json_file):
-        # According to the CORD-19 spec the JSON files have to have the
-        # keys below.
-        parser = CORD19ArticleParser(cord19_json_file)
-        assert parser.data == cord19_json_file
+# @pytest.fixture(params=sorted(jsons_path().rglob("*.json")))
+# def real_json_file(json_file_path):
+#     with json_file_path.open() as fp:
+#         json_file = json.load(fp)
+#         yield json_file
 
-        # If any of the key listed above is missing then an exception will
-        # be raised.
+
+class TestCORD19ArticleParser:
+    def test_init(self, real_json_file):
+        # Should be able to read real JSON files no problem.
+        parser = CORD19ArticleParser(real_json_file)
+        assert parser.data == real_json_file
+
+        # If any of the mandatory top-level keys are missing in the JSON file
+        # then an exception should be raised.
         with pytest.raises(ValueError, match="Incomplete JSON file"):
             CORD19ArticleParser({})
 
-    def test_get_title(self, cord19_json_file):
-        parser = CORD19ArticleParser(cord19_json_file)
+    def test_title(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
         title = parser.title
         assert title != ""
-        assert title == cord19_json_file["metadata"]["title"]
+        assert title == real_json_file["metadata"]["title"]
 
-    def test_iter_authors(self, cord19_json_file):
-        parser = CORD19ArticleParser(cord19_json_file)
+    def test_authors(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
         authors = tuple(parser.authors)
 
         # Check that all authors have been parsed
-        assert len(authors) == len(cord19_json_file["metadata"]["authors"])
+        assert len(authors) == len(real_json_file["metadata"]["authors"])
 
         # Check that all name parts of all authors have been collected
-        for author, author_dict in zip(
-            authors, cord19_json_file["metadata"]["authors"]
-        ):
+        for author, author_dict in zip(authors, real_json_file["metadata"]["authors"]):
             assert author_dict["first"] in author
             assert author_dict["last"] in author
             assert author_dict["suffix"] in author
             for middle in author_dict["middle"]:
                 assert middle in author
 
-    def test_get_abstract(self, cord19_json_file):
-        parser = CORD19ArticleParser(cord19_json_file)
+    def test_abstract(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
         abstract = parser.abstract
 
-        # Check that all paragraphs were parsed
-        assert len(abstract) == len(cord19_json_file["abstract"])
+        if "abstract" in real_json_file:
+            # Check that all paragraphs were parsed
+            assert len(abstract) == len(real_json_file["abstract"])
 
-        # Check that all paragraph texts match
-        for paragraph, paragraph_dict in zip(abstract, cord19_json_file["abstract"]):
-            assert paragraph == paragraph_dict["text"]
+            # Check that all paragraph texts match
+            for paragraph, paragraph_dict in zip(abstract, real_json_file["abstract"]):
+                assert paragraph == paragraph_dict["text"]
+        else:
+            # Check that if "abstract" is missing then an empty list is returned.
+            # This should be true for all PMC parses.
+            assert len(abstract) == 0
 
-        # Check that if "abstract" is missing then an empty list is returned
-        del cord19_json_file["abstract"]
-        parser = CORD19ArticleParser(cord19_json_file)
-        assert list(parser.abstract) == []
-
-    def test_iter_paragraphs(self, cord19_json_file):
-        parser = CORD19ArticleParser(cord19_json_file)
+    def test_paragraphs(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
         paragraphs = tuple(parser.paragraphs)
 
         # Check that all paragraphs were parsed
-        n_body_text = len(cord19_json_file["body_text"])
-        n_ref_entries = len(cord19_json_file["ref_entries"])
+        n_body_text = len(real_json_file["body_text"])
+        n_ref_entries = len(real_json_file["ref_entries"])
         assert len(paragraphs) == n_body_text + n_ref_entries
 
         # Check that all paragraph texts match
         for (section, text), paragraph_dict in zip(
-            paragraphs, cord19_json_file["body_text"]
+            paragraphs, real_json_file["body_text"]
         ):
             assert section == paragraph_dict["section"]
             assert text == paragraph_dict["text"]
 
-    def test_str(self, cord19_json_file):
-        parser = CORD19ArticleParser(cord19_json_file)
+    def test_str(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
         parser_str = str(parser)
 
         # Should be "CORD-19 article ID=<value>" or similar
         assert "CORD-19" in parser_str
-        assert str(cord19_json_file["paper_id"]) in parser_str
+        assert str(real_json_file["paper_id"]) in parser_str
 
 
 class TestArticle:
     def test_parse(self):
         # Test article parsing
-        parser = TestParser()
+        parser = SimpleTestParser()
         article = Article.parse(parser)
         assert article.title == parser.title
         assert article.authors == tuple(parser.authors)
@@ -182,7 +135,7 @@ class TestArticle:
             assert text == text_want
 
     def test_str(self):
-        parser = TestParser()
+        parser = SimpleTestParser()
         article = Article.parse(parser)
         article_str = str(article)
         assert parser.title in article_str

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -126,6 +126,11 @@ class TestCORD19ArticleParser:
         for paragraph, paragraph_dict in zip(abstract, cord19_json_file["abstract"]):
             assert paragraph == paragraph_dict["text"]
 
+        # Check that if "abstract" is missing then an empty list is returned
+        del cord19_json_file["abstract"]
+        parser = CORD19ArticleParser(cord19_json_file)
+        assert parser.get_abstract() == []
+
     def test_iter_paragraphs(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
         paragraphs = tuple(parser.iter_paragraphs())

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -70,13 +70,13 @@ class TestParser(ArticleParser):
     def get_title(self):
         return self.title
 
-    def iter_authors(self):
+    def get_authors(self):
         yield from self.authors
 
     def get_abstract(self):
         return self.abstract
 
-    def iter_paragraphs(self):
+    def get_paragraphs(self):
         yield from self.paragraphs
 
 
@@ -100,7 +100,7 @@ class TestCORD19ArticleParser:
 
     def test_iter_authors(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        authors = tuple(parser.iter_authors())
+        authors = tuple(parser.get_authors())
 
         # Check that all authors have been parsed
         assert len(authors) == len(cord19_json_file["metadata"]["authors"])
@@ -133,7 +133,7 @@ class TestCORD19ArticleParser:
 
     def test_iter_paragraphs(self, cord19_json_file):
         parser = CORD19ArticleParser(cord19_json_file)
-        paragraphs = tuple(parser.iter_paragraphs())
+        paragraphs = tuple(parser.get_paragraphs())
 
         # Check that all paragraphs were parsed
         n_body_text = len(cord19_json_file["body_text"])

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -1,0 +1,122 @@
+import pytest
+
+from bluesearch.database.article import CORD19ArticleParser
+
+
+@pytest.fixture()
+def cord19_json_file():
+    json_data = {
+        "paper_id": "93140ed88011aaef108208016a0769ad19327dae",
+        "metadata": {
+            "title": "Some Title",
+            "authors": [
+                {"first": "Jane", "middle": [], "last": "Doe", "suffix": "Dr."},
+                {"first": "Erika", "middle": [], "last": "Mustermann", "suffix": ""},
+                {"first": "Jean", "middle": ["X."], "last": "Dupont", "suffix": ""},
+                {
+                    "first": "Titius",
+                    "middle": ["J.", "K."],
+                    "last": "Seius",
+                    "suffix": "Jr.",
+                },
+            ],
+        },
+        "abstract": [
+            {
+                "section": "Abstract",
+                "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            }
+        ],
+        "body_text": [
+            {
+                "section": "Introduction",
+                "text": "Cras non ante a arcu cursus euismod id a odio.",
+            },
+            {
+                "section": "Introduction",
+                "text": "Curabitur eget est vehicula, [...], auctor erat.",
+            },
+            {
+                "section": "Conclusion",
+                "text": "Aliquam sit amet lacus vehicula, [...], eleifend odio.",
+            },
+        ],
+        "bib_entries": {},
+        "ref_entries": {},
+        "back_matter": [],
+    }
+    return json_data
+
+
+class TestCORD19ArticleParser:
+    def test_init(self, cord19_json_file):
+        # According to the CORD-19 spec the JSON files have to have the
+        # keys below.
+        parser = CORD19ArticleParser(cord19_json_file)
+        assert parser.data == cord19_json_file
+
+        # If any of the key listed above is missing then an exception will
+        # be raised.
+        with pytest.raises(ValueError, match="Incomplete JSON file"):
+            CORD19ArticleParser({})
+
+    def test_get_title(self, cord19_json_file):
+        parser = CORD19ArticleParser(cord19_json_file)
+        title = parser.get_title()
+        assert title != ""
+        assert title == cord19_json_file["metadata"]["title"]
+
+    def test_iter_authors(self, cord19_json_file):
+        parser = CORD19ArticleParser(cord19_json_file)
+        authors = tuple(parser.iter_authors())
+
+        # Check that all authors have been parsed
+        assert len(authors) == len(cord19_json_file["metadata"]["authors"])
+
+        # Check that all name parts of all authors have been collected
+        for author, author_dict in zip(
+            authors, cord19_json_file["metadata"]["authors"]
+        ):
+            assert author_dict["first"] in author
+            assert author_dict["last"] in author
+            assert author_dict["suffix"] in author
+            for middle in author_dict["middle"]:
+                assert middle in author
+
+    def test_get_abstract(self, cord19_json_file):
+        parser = CORD19ArticleParser(cord19_json_file)
+        abstract = parser.get_abstract()
+
+        # Check that all paragraphs were parsed
+        assert len(abstract) == len(cord19_json_file["abstract"])
+
+        # Check that all paragraph texts match
+        for paragraph, paragraph_dict in zip(abstract, cord19_json_file["abstract"]):
+            assert paragraph == paragraph_dict["text"]
+
+    def test_iter_paragraphs(self, cord19_json_file):
+        parser = CORD19ArticleParser(cord19_json_file)
+        paragraphs = tuple(parser.iter_paragraphs())
+
+        # Check that all paragraphs were parsed
+        assert len(paragraphs) == len(cord19_json_file["body_text"])
+
+        # Check that all paragraph texts match
+        for (section, text), paragraph_dict in zip(
+            paragraphs, cord19_json_file["body_text"]
+        ):
+            assert section == paragraph_dict["section"]
+            assert text == paragraph_dict["text"]
+
+    def test_str(self, cord19_json_file):
+        parser = CORD19ArticleParser(cord19_json_file)
+        parser_str = str(parser)
+
+        # Should be "CORD-19 article ID=<value>" or similar
+        assert "CORD-19" in parser_str
+        assert str(cord19_json_file["paper_id"]) in parser_str
+
+
+class TestArticle:
+
+    ...

--- a/tests/test_database/test_article.py
+++ b/tests/test_database/test_article.py
@@ -44,7 +44,13 @@ def cord19_json_file():
             },
         ],
         "bib_entries": {},
-        "ref_entries": {},
+        "ref_entries": {
+            "FIGREF7": {"text": "This figure shows...", "type": "figure"},
+            "TABREF23": {
+                "text": "The results are presented in the table above.",
+                "type": "table",
+            },
+        },
         "back_matter": [],
     }
     return json_data
@@ -125,7 +131,9 @@ class TestCORD19ArticleParser:
         paragraphs = tuple(parser.iter_paragraphs())
 
         # Check that all paragraphs were parsed
-        assert len(paragraphs) == len(cord19_json_file["body_text"])
+        n_body_text = len(cord19_json_file["body_text"])
+        n_ref_entries = len(cord19_json_file["ref_entries"])
+        assert len(paragraphs) == n_body_text + n_ref_entries
 
         # Check that all paragraph texts match
         for (section, text), paragraph_dict in zip(


### PR DESCRIPTION
Fixes #371 .

## Description

I drafted a proposition for the article data abstraction. Roughly the idea is the following:
- The article data is captured by the `Article` class.
- For data injestion the `ArticleParser` should be subclassed for each data source.
- For data export/writing it's possible to implement a dedicated class e.g. an `ArticleJSONWriter`.

## To Do
- [ ] Discuss if everyone's happy with the structure
- [x] Write Tests
- [ ] Integrate article abstraction into the codebase

## How to test?

You can use the following script:
```python
import json

from bluesearch.database.article import Article, CORD19ArticleParser


json_file_path = "<path to a CORD-19 JSON file>"
with open(json_file_path) as fp:
    json_data = json.load(fp)

parser = CORD19ArticleParser(json_data)
article = Article.parse(parser)

print("Article:")
print(article)
print("End.")
```

## Checklist

- [ ] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
