### PR TITLE
Add missing sklearn.metrics import in eval module

### DIFF
--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -27,6 +27,7 @@ from typing import Optional, Union
 import numpy as np
 import pandas as pd
 import sklearn
+import sklearn.metrics
 from spacy.tokens import Doc
 
 


### PR DESCRIPTION
## Description

In `bluesearch.minig.eval.ner_confusion_matrix` we use `sklearn.metrics.confusion_matrix`
but the corresponding import was missing.

## Checklist

- [ ] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
