### PR TITLE
Update URLs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     project_urls={
         "Source": "https://github.com/BlueBrain/Search",
         "Documentation": "https://blue-brain-search.readthedocs.io/en/stable/",
-        "Bug Tracker": "https://github.com/BlueBrain/Search/issues",
+        "Tracker": "https://github.com/BlueBrain/Search/issues",
     },
     license="-",
     classifiers=CLASSIFIERS,

--- a/setup.py
+++ b/setup.py
@@ -103,10 +103,11 @@ setup(
     long_description_content_type="text/x-rst",
     author="Blue Brain Project, EPFL",
     url="https://github.com/BlueBrain/Search",
+    download_url="https://pypi.python.org/pypi/bluesearch",
     project_urls={
         "Source": "https://github.com/BlueBrain/Search",
-        "Documentation": "https://bbpteam.epfl.ch/documentation",
-        "Tracker": "https://bbpteam.epfl.ch/project/issues/projects/BBS",
+        "Documentation": "https://blue-brain-search.readthedocs.io/en/stable/",
+        "Bug Tracker": "https://github.com/BlueBrain/Search/issues",
     },
     license="-",
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Fixes #397.

## Description

Some of the URLs in the `setup.py` were only accessible from Blue Brain intranet.
They are now pointing to public URLs.

## How to test?

1. Clicking on the links of the URLs should now work w/o need to login in the Blue Brain system.
2. When we push to PyPI, the links should be updated.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] All CI tests pass. 
