### PR TITLE
Fix test_get_grobid_measurements

### DIFF
--- a/tests/test_mining/test_attribute.py
+++ b/tests/test_mining/test_attribute.py
@@ -807,7 +807,7 @@ class TestAttributeExtraction:
 
         # Test 3
         response.status_code = 200
-        response._content = json.dumps({}).encode("utf-8")
+        response._content = json.dumps({"measurements": []}).encode("utf-8")
         measurements = extractor.get_grobid_measurements(text)
         assert len(measurements) == 0
 


### PR DESCRIPTION
It seems #355 CI started to fail today (14th of July) because of `test_get_grobid_measurements`. Re-triggering the current master is also failing.

## Description

It was impossible for me to reproduce this issue on other platforms (my personal mac laptop and into a docker container). 

From `test_get_grobid_measurements`
- On my personal laptop/docker container
```python
response = requests.Response()
response.status_code = 200
response._content = json.dumps({}).encode("utf-8")

# Results
response.text: '{}'
json.loads(response.text): {}
```
- In the CI:
```python
# Results
response.text: '筽'  # WHY ?
```

From the environment in the CI (yesterday on master - today on this PR), only 3 packages have different versions:

| package | before | after |
| -- | -- | -- |
| platformdirs | 2.0.0 | 2.0.2 |
| python-dateutil | 2.8.1 | 2.8.2 |
| tox | 3.23.1 | 3.24.0  |

Does anyone have an idea of the problem ? 

## How to fix ?

For now, I just replaced the empty dictionary with small dictionary containing one key. Tests are passing now.
