### PR TITLE
Fix the definition of DVC pipeline sentence_embedding

### DIFF
--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -1,34 +1,5 @@
 schema: '2.0'
 stages:
-  evaluation@biobert_nli_sts:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=biobert_nli_sts --output_dir=../../metrics/sentence_embedding
-    deps:
-    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      md5: 92a4235ce8d292ff382ce008c31da45c
-      size: 14587
-    - path: Dockerfile
-      md5: 40cc1f69daca63c2e06e23c273976661
-      size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
-    params:
-      params.yaml:
-        eval.biobert_nli_sts:
-          class: SentTransformer
-          init_kwargs:
-            model_name_or_path: clagator/biobert_v1.1_pubmed_nli_sts
-    outs:
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts.csv
-      md5: c9607e9f8af75a105f34877083a8ac58
-      size: 1256
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts.json
-      md5: 1cee2a597035c7809511315ab727af9e
-      size: 104
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts.png
-      md5: 49f0997c6d6a6e7e4e24602c077d2ebb
-      size: 153514
   training@tf_idf:
     cmd: python train.py --sentences_file=../../annotations/sentence_embedding/cord19_v47_sentences_pre.txt
       --model=tf_idf --output_dir=../../models/sentence_embedding/tf_idf
@@ -54,11 +25,15 @@ stages:
       nfiles: 1
   evaluation@tf_idf:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=tf_idf --output_dir=../../metrics/sentence_embedding
+      --model=tf_idf --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       md5: 92a4235ce8d292ff382ce008c31da45c
       size: 14587
+    - path: ../../models/sentence_embedding/tf_idf
+      md5: 596be598d693855496bd3a82894474a6.dir
+      size: 73230986
+      nfiles: 1
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
@@ -106,11 +81,15 @@ stages:
       nfiles: 1
   evaluation@count:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=count --output_dir=../../metrics/sentence_embedding
+      --model=count --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       md5: 92a4235ce8d292ff382ce008c31da45c
       size: 14587
+    - path: ../../models/sentence_embedding/count
+      md5: 8a0b977a24fe5ed2293c3fcd0288a138.dir
+      size: 38375243
+      nfiles: 1
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
@@ -133,13 +112,17 @@ stages:
     - path: ../../metrics/sentence_embedding/count.png
       md5: d68f0108ebe8c9772d13153c120471c4
       size: 86578
-  evaluation@sbert:
+  evaluation@biobert_nli_sts_cord19_v1:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=sbert --output_dir=../../metrics/sentence_embedding
+      --model=biobert_nli_sts_cord19_v1 --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       md5: 92a4235ce8d292ff382ce008c31da45c
       size: 14587
+    - path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1
+      md5: 9dccac418759a8c53f5da608dbd9f835.dir
+      size: 433540587
+      nfiles: 9
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
@@ -148,23 +131,23 @@ stages:
       size: 4513
     params:
       params.yaml:
-        eval.sbert:
+        eval.biobert_nli_sts_cord19_v1:
           class: SentTransformer
           init_kwargs:
-            model_name_or_path: bert-base-nli-mean-tokens
+            model_name_or_path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1/
     outs:
-    - path: ../../metrics/sentence_embedding/sbert.csv
-      md5: ababc62c9cae82486b214934af8932fe
-      size: 1211
-    - path: ../../metrics/sentence_embedding/sbert.json
-      md5: 612479388d464018e9dda436524e6850
-      size: 106
-    - path: ../../metrics/sentence_embedding/sbert.png
-      md5: 4b9704b24c4c51947a8fc73e03e244b2
-      size: 156836
-  evaluation@sbiobert:
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.csv
+      md5: 189a76e04b25891a80d1f48e274e3427
+      size: 1256
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.json
+      md5: 46838a489f2ac96271300f74ea2f7894
+      size: 104
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.png
+      md5: cc48fb71482f54546c848da374490b7f
+      size: 153802
+  evaluation_external@sbiobert:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=sbiobert --output_dir=../../metrics/sentence_embedding
+      --model=sbiobert --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       md5: 92a4235ce8d292ff382ce008c31da45c
@@ -191,9 +174,9 @@ stages:
     - path: ../../metrics/sentence_embedding/sbiobert.png
       md5: d4fbf9578be09263b6c5a082118172b2
       size: 155274
-  evaluation@biobert_nli_sts_cord19_v1:
+  evaluation_external@biobert_nli_sts:
     cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-      --model=biobert_nli_sts_cord19_v1 --output_dir=../../metrics/sentence_embedding
+      --model=biobert_nli_sts --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       md5: 92a4235ce8d292ff382ce008c31da45c
@@ -206,17 +189,46 @@ stages:
       size: 4513
     params:
       params.yaml:
-        eval.biobert_nli_sts_cord19_v1:
+        eval.biobert_nli_sts:
           class: SentTransformer
           init_kwargs:
-            model_name_or_path: ../../models/sentence_embedding/biobert_nli_sts_cord19_v1/
+            model_name_or_path: clagator/biobert_v1.1_pubmed_nli_sts
     outs:
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.csv
-      md5: 189a76e04b25891a80d1f48e274e3427
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.csv
+      md5: c9607e9f8af75a105f34877083a8ac58
       size: 1256
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.json
-      md5: 46838a489f2ac96271300f74ea2f7894
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.json
+      md5: 1cee2a597035c7809511315ab727af9e
       size: 104
-    - path: ../../metrics/sentence_embedding/biobert_nli_sts_cord19_v1.png
-      md5: cc48fb71482f54546c848da374490b7f
-      size: 153802
+    - path: ../../metrics/sentence_embedding/biobert_nli_sts.png
+      md5: 49f0997c6d6a6e7e4e24602c077d2ebb
+      size: 153514
+  evaluation_external@sbert:
+    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      --model=sbert --output_dir=../../metrics/sentence_embedding/
+    deps:
+    - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      md5: 92a4235ce8d292ff382ce008c31da45c
+      size: 14587
+    - path: Dockerfile
+      md5: 40cc1f69daca63c2e06e23c273976661
+      size: 1792
+    - path: eval.py
+      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
+      size: 4513
+    params:
+      params.yaml:
+        eval.sbert:
+          class: SentTransformer
+          init_kwargs:
+            model_name_or_path: bert-base-nli-mean-tokens
+    outs:
+    - path: ../../metrics/sentence_embedding/sbert.csv
+      md5: ababc62c9cae82486b214934af8932fe
+      size: 1211
+    - path: ../../metrics/sentence_embedding/sbert.json
+      md5: 612479388d464018e9dda436524e6850
+      size: 106
+    - path: ../../metrics/sentence_embedding/sbert.png
+      md5: 4b9704b24c4c51947a8fc73e03e244b2
+      size: 156836

--- a/data_and_models/pipelines/sentence_embedding/dvc.lock
+++ b/data_and_models/pipelines/sentence_embedding/dvc.lock
@@ -11,8 +11,8 @@ stages:
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
     - path: train.py
-      md5: 46f7818488bd5cb213d389b50c7277a7
-      size: 3140
+      md5: 96cba669fe0f6906f6fe6f42bfe79c44
+      size: 3196
     params:
       params.yaml:
         train.tf_idf:
@@ -24,7 +24,7 @@ stages:
       size: 73230986
       nfiles: 1
   evaluation@tf_idf:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=tf_idf --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -37,9 +37,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.tf_idf:
@@ -67,8 +67,8 @@ stages:
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
     - path: train.py
-      md5: 46f7818488bd5cb213d389b50c7277a7
-      size: 3140
+      md5: 96cba669fe0f6906f6fe6f42bfe79c44
+      size: 3196
     params:
       params.yaml:
         train.count:
@@ -80,7 +80,7 @@ stages:
       size: 38375243
       nfiles: 1
   evaluation@count:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=count --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -93,9 +93,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.count:
@@ -113,7 +113,7 @@ stages:
       md5: d68f0108ebe8c9772d13153c120471c4
       size: 86578
   evaluation@biobert_nli_sts_cord19_v1:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=biobert_nli_sts_cord19_v1 --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -126,9 +126,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.biobert_nli_sts_cord19_v1:
@@ -146,7 +146,7 @@ stages:
       md5: cc48fb71482f54546c848da374490b7f
       size: 153802
   evaluation_external@sbiobert:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=sbiobert --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -155,9 +155,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.sbiobert:
@@ -175,7 +175,7 @@ stages:
       md5: d4fbf9578be09263b6c5a082118172b2
       size: 155274
   evaluation_external@biobert_nli_sts:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=biobert_nli_sts --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -184,9 +184,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.biobert_nli_sts:
@@ -204,7 +204,7 @@ stages:
       md5: 49f0997c6d6a6e7e4e24602c077d2ebb
       size: 153514
   evaluation_external@sbert:
-    cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+    cmd: python eval_se.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       --model=sbert --output_dir=../../metrics/sentence_embedding/
     deps:
     - path: ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
@@ -213,9 +213,9 @@ stages:
     - path: Dockerfile
       md5: 40cc1f69daca63c2e06e23c273976661
       size: 1792
-    - path: eval.py
-      md5: 6e1ef54521c77c992c2fbc07be0c7bfe
-      size: 4513
+    - path: eval_se.py
+      md5: 8c85d1a2cff538b87304f223a6f66b17
+      size: 4658
     params:
       params.yaml:
         eval.sbert:

--- a/data_and_models/pipelines/sentence_embedding/dvc.yaml
+++ b/data_and_models/pipelines/sentence_embedding/dvc.yaml
@@ -17,18 +17,42 @@ stages:
   evaluation:
     foreach:
       - biobert_nli_sts_cord19_v1
-      - biobert_nli_sts
       - tf_idf
       - count
+    do:
+      cmd: >-
+        python eval.py
+        --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+        --model=${item}
+        --output_dir=../../metrics/sentence_embedding/
+      deps:
+      - Dockerfile
+      - eval.py
+      - ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+      - ../../models/sentence_embedding/${item}
+      params:
+      - eval.${item}
+      outs:
+      - ../../metrics/sentence_embedding/${item}.csv
+      - ../../metrics/sentence_embedding/${item}.png
+      metrics:
+      - ../../metrics/sentence_embedding/${item}.json:
+          cache: false
+  evaluation_external:
+    foreach:
+      - biobert_nli_sts
       - sbert
       - sbiobert
     do:
-      cmd: python eval.py --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
-        --model=${item} --output_dir=../../metrics/sentence_embedding
+      cmd: >-
+        python eval.py
+        --annotation_files=../../annotations/sentence_embedding/sentence_similarity_cord19.csv
+        --model=${item}
+        --output_dir=../../metrics/sentence_embedding/
       deps:
-      - ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       - Dockerfile
       - eval.py
+      - ../../annotations/sentence_embedding/sentence_similarity_cord19.csv
       params:
       - eval.${item}
       outs:

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -30,6 +30,9 @@ Legend
 Latest
 ======
 
+- |Fix| DVC pipeline named :code:`sentence_embedding` regarding missing
+  :code:`deps` elements and mixed models origin.
+
 
 Version 0.2.0
 ==============


### PR DESCRIPTION
Fixes #396.

## Description

See #396 for the motivation behind the PR.

The solution from the PR (bc8f9cc24111841c15c2b1ee5c8daa2af0e86c1a):
1. separates the evaluation of the models we didn't train (new stage `evaluation_external`)
2. adds the model data as `deps` for each models we trained

Note:
The `cmd` field has been reformatted for better readability.

The dvc.lock has been updated (80b308c7d268f2411403a868865e2a7420aeb07b) and `dvc push` has been executed.

## How to test?

The following now works without error:
```
git clone --branch issue_396 https://github.com/BlueBrain/Search/
export PIPELINE=data_and_models/pipelines/sentence_embedding/dvc.yaml
dvc pull -d $PIPELINE
dvc repro -f $PIPELINE
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Documentation and `whatsnew.rst` updated.
- [x] All CI tests pass. 