### PR TITLE
`bbs_database parse` and `add`: add support for multiple files

### DIFF
--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -81,7 +81,7 @@ def run(
     if parsed_path.is_file():
         inputs = [parsed_path]
     elif parsed_path.is_dir():
-        inputs = parsed_path.glob("*")
+        inputs = sorted(parsed_path.glob("*"))
     else:
         raise ValueError(
             "Argument 'parsed_path' should be a path to an existing file or directory!"

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -81,7 +81,7 @@ def run(
     if parsed_path.is_file():
         inputs = [parsed_path]
     elif parsed_path.is_dir():
-        inputs = sorted(parsed_path.glob("*"))
+        inputs = sorted(parsed_path.glob("*.pkl"))
     else:
         raise ValueError(
             "Argument 'parsed_path' should be a path to an existing file or directory!"

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -86,7 +86,7 @@ def run(
     for inp in inputs:
         parser_inst: ArticleParser
         if article_type == "cord19-json":
-            with inp.open("r") as f_inp:
+            with inp.open() as f_inp:
                 parser_inst = CORD19ArticleParser(json.load(f_inp))
         elif article_type == "pmc-xml":
             parser_inst = PubmedXMLParser(inp)

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -96,8 +96,7 @@ def run(
         article = Article.parse(parser_inst)
 
         output_path.mkdir(exist_ok=True)
-        # If we used .with_suffix(), then we would get file.pdf.xml --> file.pkl
-        out = output_path / (inp.stem + ".pkl")
+        out = (output_path / inp.name).with_suffix(".pkl")
 
         with out.open("wb") as f_out:
             pickle.dump(article, f_out)

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -77,7 +77,7 @@ def run(
     if input_path.is_file():
         inputs = [input_path]
     elif input_path.is_dir():
-        inputs = input_path.glob("*")
+        inputs = sorted(input_path.glob("*"))
     else:
         raise ValueError(
             "Argument 'input_path' should be a path to an existing file or directory!"

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -1,7 +1,25 @@
-"""Parsing an article."""
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Parsing articles."""
 import argparse
 import json
 import pickle  # nosec
+from pathlib import Path
+from typing import Iterable
 
 from bluesearch.database.article import (
     Article,
@@ -14,23 +32,32 @@ from bluesearch.database.article import (
 def get_parser() -> argparse.ArgumentParser:
     """Create a parser."""
     parser = argparse.ArgumentParser(
-        description="Parse article.",
+        description="Parse one or several articles.",
     )
     parser.add_argument(
         "article_type",
         type=str,
         choices=("cord19-json", "pmc-xml"),
-        help="""Article source type.""",
+        help="""
+        Article format. If parsing several articles, all articles
+        must have same format.
+        """,
     )
     parser.add_argument(
         "input_path",
-        type=str,
-        help="""Path to the file/directory to be parsed.""",
+        type=Path,
+        help="""
+        Path to a file or directory. If a directory, all articles
+        inside the directory will be parsed.
+        """,
     )
     parser.add_argument(
         "output_path",
-        type=str,
-        help="""Path where the parsed article is saved.""",
+        type=Path,
+        help="""
+        Path to a directory where parsed article(s) will be saved.
+        If it does not exist yet, a directory with this path is created.
+        """,
     )
     return parser
 
@@ -38,25 +65,39 @@ def get_parser() -> argparse.ArgumentParser:
 def run(
     *,
     article_type: str,
-    input_path: str,
-    output_path: str,
+    input_path: Path,
+    output_path: Path,
 ) -> None:
-    """Parse an article.
+    """Parse one or several articles.
 
     Parameter description and potential defaults are documented inside of the
     `get_parser` function.
     """
-    parser_inst: ArticleParser
-    if article_type == "cord19-json":
-        with open(input_path) as f_input:
-            parser_inst = CORD19ArticleParser(json.load(f_input))
-    elif article_type == "pmc-xml":
-        parser_inst = PubmedXMLParser(input_path)
-
+    inputs: Iterable[Path]
+    if input_path.is_file():
+        inputs = [input_path]
+    elif input_path.is_dir():
+        inputs = input_path.glob("*")
     else:
-        raise ValueError(f"Unsupported article type {article_type}")
+        raise ValueError(
+            "Argument 'input_path' should be a path to an existing file or directory!"
+        )
 
-    article = Article.parse(parser_inst)
+    for inp in inputs:
+        parser_inst: ArticleParser
+        if article_type == "cord19-json":
+            with inp.open("r") as f_inp:
+                parser_inst = CORD19ArticleParser(json.load(f_inp))
+        elif article_type == "pmc-xml":
+            parser_inst = PubmedXMLParser(inp)
+        else:
+            raise ValueError(f"Unsupported article type {article_type}")
 
-    with open(output_path, "wb") as f_output:
-        pickle.dump(article, f_output)
+        article = Article.parse(parser_inst)
+
+        output_path.mkdir(exist_ok=True)
+        # If we used .with_suffix(), then we would get file.pdf.xml --> file.pkl
+        out = output_path / (inp.stem + ".pkl")
+
+        with out.open("wb") as f_out:
+            pickle.dump(article, f_out)

--- a/tests/entrypoint/database/test_add.py
+++ b/tests/entrypoint/database/test_add.py
@@ -68,7 +68,7 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
     (n_rows,) = engine_sqlite.execute(query).fetchone()
     assert n_rows == n_files
 
-    engine_sqlite.execute("DELETE FROM articles WHERE True")
+    engine_sqlite.execute("DELETE FROM articles")
     (n_rows,) = engine_sqlite.execute(query).fetchone()
     assert n_rows == 0
 

--- a/tests/entrypoint/database/test_add.py
+++ b/tests/entrypoint/database/test_add.py
@@ -1,4 +1,3 @@
-import pathlib
 import pickle
 
 import pytest
@@ -9,8 +8,8 @@ from bluesearch.entrypoint.database.parent import main
 
 
 @pytest.fixture()
-def engine_sqlite(tmpdir):
-    db_url = pathlib.Path(str(tmpdir)) / "database.db"
+def engine_sqlite(tmp_path):
+    db_url = tmp_path / "database.db"
     eng = sqlalchemy.create_engine(f"sqlite:///{db_url}")
 
     # Schema
@@ -36,34 +35,60 @@ def test_mysql_not_implemented():
         main(["add", "a", "b", "--db-type=mysql"])
 
 
-def test_sqlite_cord19(engine_sqlite, tmpdir):
-    input_folder = pathlib.Path(str(tmpdir))
+def test_sqlite_cord19(engine_sqlite, tmp_path):
+    path_to_pkl = tmp_path / "pkl_files"
+    path_to_pkl.mkdir()
     n_files = 3
 
-    input_paths = [input_folder / f"{i}.pkl" for i in range(n_files)]
-
-    for i, input_path in enumerate(input_paths):
-        article = Article(
+    pkl_files = [path_to_pkl / f"{i}.pkl" for i in range(n_files)]
+    articles = [
+        Article(
             title=f"title_{i}",
             authors=[f"author_{i}"],
             abstract=f"abstract_{i}",
             section_paragraphs=[("Conclusion", f"conclusion_{i}")],
         )
-        with open(input_path, "wb") as f:
+        for i in range(n_files)
+    ]
+    for article, pkl_file in zip(articles, pkl_files):
+        with pkl_file.open("wb") as f:
             pickle.dump(article, f)
 
+    query = "SELECT COUNT(*) FROM articles"
+
+    # Test adding single article
+    for pkl_file in pkl_files:
         args_and_opts = [
             "add",
             engine_sqlite.url.database,
-            str(input_path),
+            str(pkl_file),
             "--db-type=sqlite",
         ]
-
         main(args_and_opts)
+    (n_rows,) = engine_sqlite.execute(query).fetchone()
+    assert n_rows == n_files
 
-    # Check
-    with engine_sqlite.begin() as connection:
-        query = """SELECT COUNT(*) FROM ARTICLES"""
-        (n_rows,) = connection.execute(query).fetchone()
+    engine_sqlite.execute("DELETE FROM articles WHERE True")
+    (n_rows,) = engine_sqlite.execute(query).fetchone()
+    assert n_rows == 0
 
-    assert n_rows == n_files > 0
+    # Test adding multiple articles
+    args_and_opts = [
+        "add",
+        engine_sqlite.url.database,
+        str(path_to_pkl),
+        "--db-type=sqlite",
+    ]
+    main(args_and_opts)
+    (n_rows,) = engine_sqlite.execute(query).fetchone()
+    assert n_rows == n_files
+
+    # Test adding something that does not exist
+    with pytest.raises(ValueError):
+        args_and_opts = [
+            "add",
+            engine_sqlite.url.database,
+            str(path_to_pkl / "dir_that_does_not_exists"),
+            "--db-type=sqlite",
+        ]
+        main(args_and_opts)


### PR DESCRIPTION
Fixes #436 .

## Description

After profiling `bbs_database parse` and `add`, it became clear that running these commands once per each file is not the most efficient approach (see detailed results [here](https://github.com/BlueBrain/Search/issues/436#issuecomment-918981263)).

With this PR, the interface of these two commands is modified to support also running on all the files contained in a given directory. Notice that the output parameter has slightly changed as well.

**Before this PR**
```bash
# Parse a file
bbs_database parse pmc-xml some_article.xml some_article.pkl

# Add a file
bbs_database add database.db some_article.pkl
```

**After this PR**
```bash
# Parse a file / multiple files
bbs_database parse pmc-xml some_article.xml pkl_files/  # parse single file
bbs_database parse pmc-xml xml_files/ pkl_files/        # parse multiple files

# Add a file / multiple files
bbs_database add database.db pkl_files/some_article.pkl  # add single file
bbs_database add database.db pkl_files/                  # add multiple files
```

## Runtime
**Before vs. After this PR**
These are the runtimes obtained by parsing/adding one file at the time, or all files together in bulk.
<img src="https://user-images.githubusercontent.com/17013890/133445022-45afa90b-6cd8-4f20-86e5-7d588144eb1b.png" width="800px">

## How to test?

For a single file:
```bash
bbs_database init tmp.db
bbs_database parse cord19-json tests/data/cord19_v35/document_parses/pmc_json/PMC7140272.xml.json pkl_parses/
bbs_database add tmp.db pkl_parses/PMC7140272.xml.pkl 
```

For multiple files:
```bash
bbs_database init tmp.db
bbs_database parse cord19-json tests/data/cord19_v35/document_parses/pmc_json/ pkl_parses/
bbs_database add tmp.db pkl_parses/
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] All CI tests pass. 
