### PR TITLE
#448 Create unique article_id column when bbs_database add is called

### DIFF
--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -21,7 +21,7 @@ import html
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Sequence
+from typing import Generator, Iterable, Optional, Sequence
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
@@ -518,6 +518,10 @@ class Article:
     authors: Sequence[str]
     abstract: Sequence[str]
     section_paragraphs: Sequence[tuple[str, str]]
+    pubmed_id: Optional[str]
+    pmc_id: Optional[str]
+    doi: Optional[str]
+    uid: Optional[str]
 
     @classmethod
     def parse(cls, parser: ArticleParser) -> Article:
@@ -532,8 +536,14 @@ class Article:
         authors = tuple(parser.authors)
         abstract = tuple(parser.abstract)
         section_paragraphs = tuple(parser.paragraphs)
+        pubmed_id = parser.pubmed_id
+        pmc_id = parser.pmc_id
+        doi = parser.doi
+        uid = parser.uid
 
-        return cls(title, authors, abstract, section_paragraphs)
+        return cls(
+            title, authors, abstract, section_paragraphs, pubmed_id, pmc_id, doi, uid
+        )
 
     def iter_paragraphs(
         self, with_abstract: bool = False

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -78,7 +78,7 @@ class ArticleParser(ABC):
         """
 
     @property
-    def pubmed_id(self) -> str | None:
+    def pubmed_id(self) -> Optional[str]:
         """Get Pubmed ID.
 
         Returns
@@ -89,7 +89,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def pmc_id(self) -> str | None:
+    def pmc_id(self) -> Optional[str]:
         """Get PMC ID.
 
         Returns
@@ -100,7 +100,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def doi(self) -> str | None:
+    def doi(self) -> Optional[str]:
         """Get DOI.
 
         Returns
@@ -111,7 +111,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def uid(self) -> str | None:
+    def uid(self) -> Optional[str]:
         """Generate unique ID of the article based on different identifiers.
 
         Returns
@@ -238,7 +238,7 @@ class PubmedXMLParser(ArticleParser):
             yield "Table Caption", caption
 
     @property
-    def pubmed_id(self) -> str | None:
+    def pubmed_id(self) -> Optional[str]:
         """Get Pubmed ID.
 
         Returns
@@ -249,7 +249,7 @@ class PubmedXMLParser(ArticleParser):
         return self.ids.get("pmid")
 
     @property
-    def pmc_id(self) -> str | None:
+    def pmc_id(self) -> Optional[str]:
         """Get PMC ID.
 
         Returns
@@ -260,7 +260,7 @@ class PubmedXMLParser(ArticleParser):
         return self.ids.get("pmc")
 
     @property
-    def doi(self) -> str | None:
+    def doi(self) -> Optional[str]:
         """Get DOI.
 
         Returns
@@ -495,7 +495,7 @@ class CORD19ArticleParser(ArticleParser):
             yield "Caption", ref_entry["text"]
 
     @property
-    def pmc_id(self) -> str | None:
+    def pmc_id(self) -> Optional[str]:
         """Get PMC ID.
 
         Returns
@@ -503,7 +503,7 @@ class CORD19ArticleParser(ArticleParser):
         str or None
             PMC ID if specified, otherwise None.
         """
-        return self.data["paper_id"]
+        return self.data.get("paper_id")
 
     def __str__(self):
         """Get the string representation of the parser instance."""

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -68,7 +68,6 @@ def run(
 
     import sqlalchemy
 
-    from bluesearch.database.identifiers import generate_uid
     from bluesearch.utils import load_spacy_model
 
     if db_type == "sqlite":
@@ -104,13 +103,14 @@ def run(
 
     for article in articles:
 
-        # TODO At the moment, no identifiers are extracted. This is a patch meanwhile.
-        article_id = generate_uid((article.title,))
         article_mapping = {
-            "article_id": article_id,
+            "article_id": article.uid,
             "title": article.title,
             "authors": ", ".join(article.authors),
             "abstract": "\n".join(article.abstract),
+            "pubmed_id": article.pubmed_id,
+            "pmc_id": article.pmc_id,
+            "doi": article.doi,
         }
         article_mappings.append(article_mapping)
 
@@ -123,7 +123,7 @@ def run(
                 sentence_mapping = {
                     "section_name": section,
                     "text": sent.text,
-                    "article_id": article_id,
+                    "article_id": article.uid,
                     "paragraph_pos_in_article": ppos,
                     "sentence_pos_in_paragraph": spos,
                 }
@@ -131,7 +131,15 @@ def run(
 
     # Persistence.
 
-    article_keys = ["article_id", "title", "authors", "abstract"]
+    article_keys = [
+        "article_id",
+        "title",
+        "authors",
+        "abstract",
+        "pubmed_id",
+        "pmc_id",
+        "doi",
+    ]
     article_fields = ", ".join(article_keys)
     article_binds = f":{', :'.join(article_keys)}"
     article_query = sqlalchemy.text(

--- a/tests/data/sample_file.xml
+++ b/tests/data/sample_file.xml
@@ -20,6 +20,7 @@
             <article-id pub-id-type="publisher-id">Publisher ID</article-id>
             <article-id pub-id-type="publisher-id">Publisher ID 2</article-id>
             <article-id pub-id-type="doi">DOI</article-id>
+            <article-id pub-id-type="pmc">PMC</article-id>
             <article-id pub-id-type="other">other</article-id>
             <article-id pub-id-type="pmid">PMID</article-id>
             <article-version vocab="JAV"

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -24,6 +24,10 @@ class SimpleTestParser(ArticleParser):
             ("Section 1", "Paragraph 2."),
             ("Section 2", "Paragraph 1."),
         ]
+        self._pubmed_id = "pubmed_id"
+        self._pmc_id = "pmc_id"
+        self._doi = "doi"
+        self._uid = "fake_uid"
 
     @property
     def title(self):
@@ -40,6 +44,22 @@ class SimpleTestParser(ArticleParser):
     @property
     def paragraphs(self):
         yield from self._paragraphs
+
+    @property
+    def pubmed_id(self):
+        return self._pubmed_id
+
+    @property
+    def pmc_id(self):
+        return self._pmc_id
+
+    @property
+    def doi(self):
+        return self._doi
+
+    @property
+    def uid(self):
+        return self._uid
 
 
 @pytest.fixture(scope="session")
@@ -92,6 +112,26 @@ class TestPubmedXMLArticleParser:
         assert paragraphs[0] == ("", "Paragraph 1")
         assert paragraphs[3] == ("Section Title 1", "Paragraph Section 1")
         assert paragraphs[4] == ("Section Title 2", "Paragraph Section 2")
+
+    def test_pubmed_id(self, pubmed_xml_parser):
+        pubmed_id = pubmed_xml_parser.pubmed_id
+        assert isinstance(pubmed_id, str)
+        assert pubmed_id == "PMID"
+
+    def test_pmc_id(self, pubmed_xml_parser):
+        pmc_id = pubmed_xml_parser.pmc_id
+        assert isinstance(pmc_id, str)
+        assert pmc_id == "PMC"
+
+    def test_doi(self, pubmed_xml_parser):
+        doi = pubmed_xml_parser.doi
+        assert isinstance(doi, str)
+        assert doi == "DOI"
+
+    def test_uid(self, pubmed_xml_parser):
+        uid = pubmed_xml_parser.uid
+        assert isinstance(uid, str)
+        assert len(uid) == 32
 
     @pytest.mark.parametrize(
         ("input_xml", "expected_inner_text"),
@@ -213,6 +253,29 @@ class TestCORD19ArticleParser:
         ):
             assert section == paragraph_dict["section"]
             assert text == paragraph_dict["text"]
+
+    def test_pubmed_id(self, real_json_file):
+        # There is no Pubmed ID specified in the schema of CORD19 json files
+        parser = CORD19ArticleParser(real_json_file)
+        pubmed_id = parser.pubmed_id
+        assert pubmed_id is None
+
+    def test_pmc_id(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
+        pmc_id = parser.pmc_id
+        assert isinstance(pmc_id, str)
+
+    def test_doi(self, real_json_file):
+        # There is no DOI specified in the schema of CORD19 json files
+        parser = CORD19ArticleParser(real_json_file)
+        doi = parser.doi
+        assert doi is None
+
+    def test_uid(self, real_json_file):
+        parser = CORD19ArticleParser(real_json_file)
+        uid = parser.uid
+        assert isinstance(uid, str)
+        assert len(uid) == 32
 
     def test_str(self, real_json_file):
         parser = CORD19ArticleParser(real_json_file)

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -37,6 +37,10 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
             authors=[f"author_{i}"],
             abstract=f"abstract_{i}",
             section_paragraphs=[("Conclusion", f"conclusion_{i}")],
+            uid=f"uid_{i}",
+            pubmed_id=f"pubmed_id_{i}",
+            pmc_id=f"pmc_id_{i}",
+            doi=f"doi_{i}",
         )
         for i in range(n_files)
     ]


### PR DESCRIPTION
Fixes #448.

## Description

This PR handles the concrete parsing of articles identifiers (currently namely: `(PubMed ID, PMC ID and DOI)`) and the generation of the unique ID. 
- All of them can be found in the schema of `XML` files of PMC papers. 
- Only `PMC` id is specified concerning the `json` files of CORD-19.
- From PMC papers on DGX1:
    - All of them possess a PMC ID.
    - PubMed ID is specified in 89.85 %.
    - DOI is specified in 83.51 %.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
