### PR TITLE
Add JSON serialization for dataclass Article

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,7 @@ Legend
 
 Latest
 ======
+- |Change| serialization of processed articles from Pickle to JSON format.
 - |Add| command line entrypoints :code:`bbs_database init`,
   :code:`bbs_database parse`, and :code:`bbs_database add` to initialize
   a literature database, parse, and integrate articles.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,9 +26,9 @@ ipython==7.25.0
 ipywidgets==7.6.3
 jupyterlab==3.0.17
 langdetect==1.0.9
+mashumaro==2.7
 numpy==1.21.0
 pandas==1.3.0
-pyserde==0.4.0
 python-dotenv==0.18.0
 requests==2.26.0
 scikit-learn==0.24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ jupyterlab==3.0.17
 langdetect==1.0.9
 numpy==1.21.0
 pandas==1.3.0
+pyserde==0.4.0
 python-dotenv==0.18.0
 requests==2.26.0
 scikit-learn==0.24.2

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ INSTALL_REQUIRES = [
     "langdetect",
     "numpy>=1.20.1",
     "pandas>=1",
-    "pyserde",
+    "mashumaro",
     "python-dotenv",
     "requests",
     "scikit-learn",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ INSTALL_REQUIRES = [
     "langdetect",
     "numpy>=1.20.1",
     "pandas>=1",
+    "pyserde",
     "python-dotenv",
     "requests",
     "scikit-learn",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ INSTALL_REQUIRES = [
     "langdetect",
     "numpy>=1.20.1",
     "pandas>=1",
+    # Serialization framework on top of dataclasses, e.g. 'Article' to and from JSON.
     "mashumaro",
     "python-dotenv",
     "requests",

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -21,10 +21,11 @@ import html
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Sequence
+from typing import Generator, Iterable, List, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
+from serde import deserialize, serialize
 
 
 class ArticleParser(ABC):
@@ -398,14 +399,16 @@ class CORD19ArticleParser(ArticleParser):
         return f'CORD-19 article ID={self.data["paper_id"]}'
 
 
+@deserialize
+@serialize
 @dataclass(frozen=True)
 class Article:
     """Abstraction of a scientific article and its contents."""
 
     title: str
-    authors: Sequence[str]
-    abstract: Sequence[str]
-    section_paragraphs: Sequence[tuple[str, str]]
+    authors: List[str]
+    abstract: List[str]
+    section_paragraphs: List[Tuple[str, str]]
 
     @classmethod
     def parse(cls, parser: ArticleParser) -> Article:
@@ -417,9 +420,9 @@ class Article:
             An article parser instance.
         """
         title = parser.title
-        authors = tuple(parser.authors)
-        abstract = tuple(parser.abstract)
-        section_paragraphs = tuple(parser.paragraphs)
+        authors = list(parser.authors)
+        abstract = list(parser.abstract)
+        section_paragraphs = list(parser.paragraphs)
 
         return cls(title, authors, abstract, section_paragraphs)
 

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -21,11 +21,11 @@ import html
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Optional, Tuple
+from typing import Generator, Iterable, Optional, Sequence, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
-from serde import deserialize, serialize
+from mashumaro import DataClassJSONMixin
 
 from bluesearch.database.identifiers import generate_uid
 
@@ -511,16 +511,14 @@ class CORD19ArticleParser(ArticleParser):
         return f'CORD-19 article ID={self.data["paper_id"]}'
 
 
-@deserialize
-@serialize
 @dataclass(frozen=True)
-class Article:
+class Article(DataClassJSONMixin):
     """Abstraction of a scientific article and its contents."""
 
     title: str
-    authors: Tuple[str, ...]
-    abstract: Tuple[str, ...]
-    section_paragraphs: Tuple[Tuple[str, str], ...]
+    authors: Sequence[str]
+    abstract: Sequence[str]
+    section_paragraphs: Sequence[Tuple[str, str]]
     pubmed_id: Optional[str]
     pmc_id: Optional[str]
     doi: Optional[str]

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -21,7 +21,7 @@ import html
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, List, Optional, Tuple
+from typing import Generator, Iterable, Optional, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
@@ -518,9 +518,9 @@ class Article:
     """Abstraction of a scientific article and its contents."""
 
     title: str
-    authors: List[str]
-    abstract: List[str]
-    section_paragraphs: List[Tuple[str, str]]
+    authors: Tuple[str, ...]
+    abstract: Tuple[str, ...]
+    section_paragraphs: Tuple[Tuple[str, str], ...]
     pubmed_id: Optional[str]
     pmc_id: Optional[str]
     doi: Optional[str]
@@ -536,9 +536,9 @@ class Article:
             An article parser instance.
         """
         title = parser.title
-        authors = list(parser.authors)
-        abstract = list(parser.abstract)
-        section_paragraphs = list(parser.paragraphs)
+        authors = tuple(parser.authors)
+        abstract = tuple(parser.abstract)
+        section_paragraphs = tuple(parser.paragraphs)
         pubmed_id = parser.pubmed_id
         pmc_id = parser.pmc_id
         doi = parser.doi

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -63,11 +63,12 @@ def run(
     Parameter description and potential defaults are documented inside of the
     `get_parser` function.
     """
-    import pickle  # nosec
     from typing import Iterable
 
     import sqlalchemy
+    from serde.json import from_json
 
+    from bluesearch.database.article import Article
     from bluesearch.database.identifiers import generate_uid
     from bluesearch.utils import load_spacy_model
 
@@ -85,7 +86,7 @@ def run(
     if parsed_path.is_file():
         inputs = [parsed_path]
     elif parsed_path.is_dir():
-        inputs = sorted(parsed_path.glob("*.pkl"))
+        inputs = sorted(parsed_path.glob("*.json"))
     else:
         raise ValueError(
             "Argument 'parsed_path' should be a path to an existing file or directory!"
@@ -93,9 +94,9 @@ def run(
 
     articles = []
     for inp in inputs:
-        with inp.open("rb") as f:
-            article = pickle.load(f)  # nosec
-            articles.append(article)
+        serialized = inp.read_text("utf-8")
+        article = from_json(Article, serialized)
+        articles.append(article)
 
     nlp = load_spacy_model("en_core_sci_lg", disable=["ner"])
 

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -66,7 +66,6 @@ def run(
     from typing import Iterable
 
     import sqlalchemy
-    from serde.json import from_json
 
     from bluesearch.database.article import Article
     from bluesearch.utils import load_spacy_model
@@ -94,7 +93,7 @@ def run(
     articles = []
     for inp in inputs:
         serialized = inp.read_text("utf-8")
-        article = from_json(Article, serialized)
+        article = Article.from_json(serialized)
         articles.append(article)
 
     nlp = load_spacy_model("en_core_sci_lg", disable=["ner"])

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -21,8 +21,6 @@ import warnings
 from pathlib import Path
 from typing import Iterable
 
-from serde.json import to_json
-
 from bluesearch.database.article import (
     Article,
     ArticleParser,
@@ -100,7 +98,7 @@ def run(
 
             article = Article.parse(parser_inst)
 
-            serialized = to_json(article)
+            serialized = article.to_json()
             out = (output_path / inp.name).with_suffix(".json")
             out.write_text(serialized, "utf-8")
 

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -17,10 +17,11 @@
 """Parsing articles."""
 import argparse
 import json
-import pickle  # nosec
 import warnings
 from pathlib import Path
 from typing import Iterable
+
+from serde.json import to_json
 
 from bluesearch.database.article import (
     Article,
@@ -99,9 +100,9 @@ def run(
 
             article = Article.parse(parser_inst)
 
-            out = (output_path / inp.name).with_suffix(".pkl")
-            with out.open("wb") as f_out:
-                pickle.dump(article, f_out)
+            serialized = to_json(article)
+            out = (output_path / inp.name).with_suffix(".json")
+            out.write_text(serialized, "utf-8")
 
         except Exception as e:
             warnings.warn(

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -80,7 +80,7 @@ class TestPubmedXMLArticleParser:
     def test_authors(self, pubmed_xml_parser):
         authors = pubmed_xml_parser.authors
         assert inspect.isgenerator(authors)
-        authors = list(authors)
+        authors = tuple(authors)
 
         assert len(authors) == 2
         assert authors[0] == "Author Given Names 1 Author Surname 1"
@@ -89,7 +89,7 @@ class TestPubmedXMLArticleParser:
     def test_abstract(self, pubmed_xml_parser):
         abstract = pubmed_xml_parser.abstract
         assert inspect.isgenerator(abstract)
-        abstract = list(abstract)
+        abstract = tuple(abstract)
         assert len(abstract) == 2
         assert abstract[0] == "Abstract Paragraph 1"
         assert abstract[1] == "Abstract Paragraph 2"
@@ -97,7 +97,7 @@ class TestPubmedXMLArticleParser:
     def test_paragraphs(self, pubmed_xml_parser):
         paragraphs = pubmed_xml_parser.paragraphs
         assert inspect.isgenerator(paragraphs)
-        paragraphs = list(paragraphs)
+        paragraphs = tuple(paragraphs)
         assert len(paragraphs) == 7 + 1 + 3  # for paragraph, caption, table
 
         for i, paragraph in enumerate(paragraphs):
@@ -209,7 +209,7 @@ class TestCORD19ArticleParser:
 
     def test_authors(self, real_json_file):
         parser = CORD19ArticleParser(real_json_file)
-        authors = list(parser.authors)
+        authors = tuple(parser.authors)
 
         # Check that all authors have been parsed
         assert len(authors) == len(real_json_file["metadata"]["authors"])
@@ -240,7 +240,7 @@ class TestCORD19ArticleParser:
 
     def test_paragraphs(self, real_json_file):
         parser = CORD19ArticleParser(real_json_file)
-        paragraphs = list(parser.paragraphs)
+        paragraphs = tuple(parser.paragraphs)
 
         # Check that all paragraphs were parsed
         n_body_text = len(real_json_file["body_text"])
@@ -292,7 +292,7 @@ class TestArticle:
         parser = SimpleTestParser()
         article = Article.parse(parser)
         assert article.title == parser.title
-        assert article.authors == list(parser.authors)
+        assert article.authors == tuple(parser.authors)
 
         # Test iterating over all paragraphs in the article. By default the
         # abstract is not included

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -80,7 +80,7 @@ class TestPubmedXMLArticleParser:
     def test_authors(self, pubmed_xml_parser):
         authors = pubmed_xml_parser.authors
         assert inspect.isgenerator(authors)
-        authors = tuple(authors)
+        authors = list(authors)
 
         assert len(authors) == 2
         assert authors[0] == "Author Given Names 1 Author Surname 1"
@@ -89,7 +89,7 @@ class TestPubmedXMLArticleParser:
     def test_abstract(self, pubmed_xml_parser):
         abstract = pubmed_xml_parser.abstract
         assert inspect.isgenerator(abstract)
-        abstract = tuple(abstract)
+        abstract = list(abstract)
         assert len(abstract) == 2
         assert abstract[0] == "Abstract Paragraph 1"
         assert abstract[1] == "Abstract Paragraph 2"
@@ -97,7 +97,7 @@ class TestPubmedXMLArticleParser:
     def test_paragraphs(self, pubmed_xml_parser):
         paragraphs = pubmed_xml_parser.paragraphs
         assert inspect.isgenerator(paragraphs)
-        paragraphs = tuple(paragraphs)
+        paragraphs = list(paragraphs)
         assert len(paragraphs) == 7 + 1 + 3  # for paragraph, caption, table
 
         for i, paragraph in enumerate(paragraphs):
@@ -209,7 +209,7 @@ class TestCORD19ArticleParser:
 
     def test_authors(self, real_json_file):
         parser = CORD19ArticleParser(real_json_file)
-        authors = tuple(parser.authors)
+        authors = list(parser.authors)
 
         # Check that all authors have been parsed
         assert len(authors) == len(real_json_file["metadata"]["authors"])
@@ -240,7 +240,7 @@ class TestCORD19ArticleParser:
 
     def test_paragraphs(self, real_json_file):
         parser = CORD19ArticleParser(real_json_file)
-        paragraphs = tuple(parser.paragraphs)
+        paragraphs = list(parser.paragraphs)
 
         # Check that all paragraphs were parsed
         n_body_text = len(real_json_file["body_text"])
@@ -292,7 +292,7 @@ class TestArticle:
         parser = SimpleTestParser()
         article = Article.parse(parser)
         assert article.title == parser.title
-        assert article.authors == tuple(parser.authors)
+        assert article.authors == list(parser.authors)
 
         # Test iterating over all paragraphs in the article. By default the
         # abstract is not included

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -33,9 +33,9 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
     articles = [
         Article(
             title=f"title_{i}",
-            authors=[f"author_{i}"],
-            abstract=[f"abstract_{i}"],
-            section_paragraphs=[("Conclusion", f"conclusion_{i}")],
+            authors=(f"author_{i}",),
+            abstract=(f"abstract_{i}",),
+            section_paragraphs=(("Conclusion", f"conclusion_{i}"),),
             uid=f"uid_{i}",
             pubmed_id=f"pubmed_id_{i}",
             pmc_id=f"pmc_id_{i}",

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -1,6 +1,5 @@
 import pytest
 import sqlalchemy
-from serde.json import to_json
 
 from bluesearch.database.article import Article
 from bluesearch.entrypoint.database.parent import main
@@ -25,11 +24,11 @@ def engine_sqlite(tmp_path):
 
 
 def test_sqlite_cord19(engine_sqlite, tmp_path):
-    path_to_json = tmp_path / "json_files"
-    path_to_json.mkdir()
+    parsed_dir = tmp_path / "parsed_files"
+    parsed_dir.mkdir()
     n_files = 3
 
-    json_files = [path_to_json / f"{i}.json" for i in range(n_files)]
+    parsed_files = [parsed_dir / f"{i}.json" for i in range(n_files)]
     articles = [
         Article(
             title=f"title_{i}",
@@ -43,19 +42,19 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
         )
         for i in range(n_files)
     ]
-    for article, json_file in zip(articles, json_files):
-        serialized = to_json(article)
-        json_file.write_text(serialized, "utf-8")
+    for article, parsed_file in zip(articles, parsed_files):
+        serialized = article.to_json()
+        parsed_file.write_text(serialized, "utf-8")
 
     query_articles = "SELECT COUNT(*) FROM articles"
     query_sentences = "SELECT COUNT(*) FROM sentences"
 
     # Test adding single article
-    for json_file in json_files:
+    for parsed_file in parsed_files:
         args_and_opts = [
             "add",
             engine_sqlite.url.database,
-            str(json_file),
+            str(parsed_file),
             "--db-type=sqlite",
         ]
         main(args_and_opts)
@@ -78,7 +77,7 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
     args_and_opts = [
         "add",
         engine_sqlite.url.database,
-        str(path_to_json),
+        str(parsed_dir),
         "--db-type=sqlite",
     ]
     main(args_and_opts)
@@ -94,7 +93,7 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
         args_and_opts = [
             "add",
             engine_sqlite.url.database,
-            str(path_to_json / "dir_that_does_not_exists"),
+            str(parsed_dir / "dir_that_does_not_exists"),
             "--db-type=sqlite",
         ]
         main(args_and_opts)

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -34,7 +34,7 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
         Article(
             title=f"title_{i}",
             authors=[f"author_{i}"],
-            abstract=f"abstract_{i}",
+            abstract=[f"abstract_{i}"],
             section_paragraphs=[("Conclusion", f"conclusion_{i}")],
             uid=f"uid_{i}",
             pubmed_id=f"pubmed_id_{i}",

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -33,7 +33,7 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
         Article(
             title=f"title_{i}",
             authors=[f"author_{i}"],
-            abstract=[f"abstract_{i}"],
+            abstract=f"abstract_{i}",
             section_paragraphs=[("Conclusion", f"conclusion_{i}")],
             uid=f"uid_{i}",
             pubmed_id=f"pubmed_id_{i}",

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -32,9 +32,9 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
     articles = [
         Article(
             title=f"title_{i}",
-            authors=(f"author_{i}",),
-            abstract=(f"abstract_{i}",),
-            section_paragraphs=(("Conclusion", f"conclusion_{i}"),),
+            authors=[f"author_{i}"],
+            abstract=[f"abstract_{i}"],
+            section_paragraphs=[("Conclusion", f"conclusion_{i}")],
             uid=f"uid_{i}",
             pubmed_id=f"pubmed_id_{i}",
             pmc_id=f"pmc_id_{i}",

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -1,7 +1,7 @@
-import pickle
 from argparse import ArgumentError
 
 import pytest
+from serde.json import from_json
 
 from bluesearch.database.article import Article
 from bluesearch.entrypoint.database.parent import main
@@ -39,10 +39,11 @@ def test_cord19_json(jsons_path, tmp_path):
         out_files = list(out_dir.glob("*"))
 
         assert len(out_files) == 1
-        assert out_files[0].name == inp_file.stem + ".pkl"
-        with out_files[0].open("rb") as f:
-            loaded_article = pickle.load(f)
-            assert isinstance(loaded_article, Article)
+        assert out_files[0].name == inp_file.stem + ".json"
+
+        serialized = out_files[0].read_text("utf-8")
+        loaded_article = from_json(Article, serialized)
+        assert isinstance(loaded_article, Article)
 
     # Test parsing multiple files
     out_dir = tmp_path / "all"
@@ -56,11 +57,13 @@ def test_cord19_json(jsons_path, tmp_path):
     out_files = sorted(out_dir.glob("*"))
 
     assert len(out_files) == len(json_files)
+
     for inp_file, out_file in zip(json_files, out_files):
-        assert out_file.name == inp_file.stem + ".pkl"
-        with out_file.open("rb") as f:
-            loaded_article = pickle.load(f)
-            assert isinstance(loaded_article, Article)
+        assert out_file.name == inp_file.stem + ".json"
+
+        serialized = out_file.read_text("utf-8")
+        loaded_article = from_json(Article, serialized)
+        assert isinstance(loaded_article, Article)
 
     # Test parsing something that doesn't exist
     with pytest.raises(ValueError):

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentError
 
 import pytest
-from serde.json import from_json
 
 from bluesearch.database.article import Article
 from bluesearch.entrypoint.database.parent import main
@@ -42,7 +41,7 @@ def test_cord19_json(jsons_path, tmp_path):
         assert out_files[0].name == inp_file.stem + ".json"
 
         serialized = out_files[0].read_text("utf-8")
-        loaded_article = from_json(Article, serialized)
+        loaded_article = Article.from_json(serialized)
         assert isinstance(loaded_article, Article)
 
     # Test parsing multiple files
@@ -62,7 +61,7 @@ def test_cord19_json(jsons_path, tmp_path):
         assert out_file.name == inp_file.stem + ".json"
 
         serialized = out_file.read_text("utf-8")
-        loaded_article = from_json(Article, serialized)
+        loaded_article = Article.from_json(serialized)
         assert isinstance(loaded_article, Article)
 
     # Test parsing something that doesn't exist


### PR DESCRIPTION
Fixes #422.

## Description

Between parsing and loading, the data of `Article` instances are serialized as `pickle` files. This implements the best practice named 'separation of concerns'. Indeed, the logic for parsing raw data into `Article` instances and the logic for loading `Article` instances in the database are then separated.

The issue #422 wants to move away from the `pickle` format. Indeed, the tool `bandit` warns against it. If someone would have added malicious code to the serialized `Article` instances, deserializing the data could lead to execute malicious code.

➡️ The goal of the current PR is then to replace the `pickle` format with another format. This other format is `JSON`.

A Python library named `mashumaro` ([PyPI](https://pypi.org/project/mashumaro/)), lets serialize and deserialize a `dataclass` into several formats. One is `JSON`.

The type annotation `tuple[]` was replaced with `Tuple[]`. Indeed, we use a bit of this Python 3.9+ style for typing (`tuple[str, str]`) thanks to a `__future__` import. However, `mashumaro` uses this Python 3.9+ style only on Python 3.9+.

## How to test?

The changes are automatically tested by these tests:
- `tests/unit/entrypoint/database/test_parse.py`
- `tests/unit/entrypoint/database/test_add.py`

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Documentation and `whatsnew.rst` updated.
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
- [x] All CI tests pass. 