### PR TITLE
Stop when no article or sentence to load in the database

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,11 @@ Legend
 
 Latest
 ======
+- |Change| the behaviour of :code:`bbs_database add` when no article was loaded
+  from the given path. Now, stop with a :code:`RuntimeWarning` and don't load
+  the NLP model to get sentences (fail faster).
+- |Change| the behaviour of :code:`bbs_database add` when no sentence was
+  extracted from the given path, Now, stop with a :code:`RuntimeWarning`.
 - |Add| command line entrypoints :code:`bbs_database init`,
   :code:`bbs_database parse`, and :code:`bbs_database add` to initialize
   a literature database, parse, and integrate articles.

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -96,6 +96,9 @@ def run(
             article = pickle.load(f)  # nosec
             articles.append(article)
 
+    if not articles:
+        raise RuntimeWarning(f"No article was loaded from '{parsed_path}'!")
+
     nlp = load_spacy_model("en_core_sci_lg", disable=["ner"])
 
     article_mappings = []
@@ -148,6 +151,9 @@ def run(
 
     with engine.begin() as con:
         con.execute(article_query, *article_mappings)
+
+    if not sentence_mappings:
+        raise RuntimeWarning(f"No sentence was extracted from '{parsed_path}'!")
 
     sentences_keys = [
         "section_name",

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -100,16 +100,16 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
 
 
 def test_no_articles(tmp_path):
-    empty_dir = tmp_path / "empty"
-    empty_dir.mkdir()
+    parsed_dir = tmp_path / "empty"
+    parsed_dir.mkdir()
 
     with pytest.raises(RuntimeWarning, match=r"No article was loaded from '.*'!"):
-        main(["add", "test.db", str(empty_dir)])
+        main(["add", "test.db", str(parsed_dir)])
 
 
 def test_no_sentences(tmp_path, engine_sqlite):
-    path_dir = tmp_path / "parsed_files"
-    path_dir.mkdir()
+    parsed_dir = tmp_path / "parsed_files"
+    parsed_dir.mkdir()
 
     article = Article(
         title="Title",
@@ -122,9 +122,9 @@ def test_no_sentences(tmp_path, engine_sqlite):
         uid="UID",
     )
 
-    path = path_dir / "article.pkl"
-    with path.open("wb") as f:
-        pickle.dump(article, f)
+    serialized = article.to_json()
+    parsed_file = parsed_dir / "article.pkl"
+    parsed_file.write_text(serialized, "utf-8")
 
     with pytest.raises(RuntimeWarning, match=r"No sentence was extracted from '.*'!"):
-        main(["add", engine_sqlite.url.database, str(path)])
+        main(["add", engine_sqlite.url.database, str(parsed_file)])

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -99,3 +99,34 @@ def test_sqlite_cord19(engine_sqlite, tmp_path):
             "--db-type=sqlite",
         ]
         main(args_and_opts)
+
+
+def test_no_articles(tmp_path):
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    with pytest.raises(RuntimeWarning, match=r"No article was loaded from '.*'!"):
+        main(["add", "test.db", str(empty_dir)])
+
+
+def test_no_sentences(tmp_path, engine_sqlite):
+    path_dir = tmp_path / "parsed_files"
+    path_dir.mkdir()
+
+    article = Article(
+        title="Title",
+        authors=["Author"],
+        abstract="Abstract",
+        section_paragraphs=[],
+        pubmed_id="PubMed ID",
+        pmc_id="PMC ID",
+        doi="DOI",
+        uid="UID",
+    )
+
+    path = path_dir / "article.pkl"
+    with path.open("wb") as f:
+        pickle.dump(article, f)
+
+    with pytest.raises(RuntimeWarning, match=r"No sentence was extracted from '.*'!"):
+        main(["add", engine_sqlite.url.database, str(path)])


### PR DESCRIPTION
Fixes #461.

## Description

Two new behaviours for `bbs_database`:

1. If no article was loaded from the given path, stop and don't load the NLP model to get sentences (fail faster)

2. If no sentence was extracted from the given path, stop.

## How to test?

The following automatic tests in `test_add.py` check the new behaviours:
- `test_no_articles()`
- `test_no_sentences()`

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
- [x] Unit tests added.
- [x] Documentation and `whatsnew.rst` updated.
- [x] All CI tests pass. 