### PR TITLE
New CLI organization + introducing logging

### DIFF
--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -23,11 +23,23 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """Create a parser."""
-    parser = argparse.ArgumentParser(
-        description="Add entries to the database.",
-    )
+def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Initialise the argument parser for the add subcommand.
+
+    Parameters
+    ----------
+    parser
+        The argument parser to initialise.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The initialised argument parser. The same object as the `parser`
+        argument.
+    """
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description = "Add entries to the database."
+
     parser.add_argument(
         "db_url",
         type=str,
@@ -174,3 +186,5 @@ def run(
 
     with engine.begin() as con:
         con.execute(sentence_query, *sentence_mappings)
+
+    return 0

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -36,7 +36,6 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         The initialised argument parser. The same object as the `parser`
         argument.
     """
-    parser.formatter_class = argparse.RawDescriptionHelpFormatter
     parser.description = "Add entries to a database."
 
     parser.add_argument(

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -19,7 +19,6 @@ import argparse
 import logging
 from pathlib import Path
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -38,7 +38,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         argument.
     """
     parser.formatter_class = argparse.RawDescriptionHelpFormatter
-    parser.description = "Add entries to the database."
+    parser.description = "Add entries to a database."
 
     parser.add_argument(
         "db_url",

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -16,7 +16,11 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Adding articles to the database."""
 import argparse
+import logging
 from pathlib import Path
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -72,7 +72,7 @@ def run(
     db_url: str,
     parsed_path: Path,
     db_type: str,
-) -> None:
+) -> int:
     """Add an entry to the database.
 
     Parameter description and potential defaults are documented inside of the

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -114,8 +114,11 @@ def run(
     if not articles:
         raise RuntimeWarning(f"No article was loaded from '{parsed_path}'!")
 
+    logger.info("Loading spacy model")
     nlp = load_spacy_model("en_core_sci_lg", disable=["ner"])
 
+
+    logger.info("Splitting text into sentences")
     article_mappings = []
     sentence_mappings = []
 
@@ -164,6 +167,7 @@ def run(
         f"INSERT INTO articles({article_fields}) VALUES({article_binds})"
     )
 
+    logger.info("Adding entries to the articles table")
     with engine.begin() as con:
         con.execute(article_query, *article_mappings)
 
@@ -183,7 +187,9 @@ def run(
         f"INSERT INTO sentences({sentences_fields}) VALUES({sentences_binds})"
     )
 
+    logger.info("Adding entries to the sentences table")
     with engine.begin() as con:
         con.execute(sentence_query, *sentence_mappings)
 
+    logger.info("Adding done")
     return 0

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -117,7 +117,6 @@ def run(
     logger.info("Loading spacy model")
     nlp = load_spacy_model("en_core_sci_lg", disable=["ner"])
 
-
     logger.info("Splitting text into sentences")
     article_mappings = []
     sentence_mappings = []

--- a/src/bluesearch/entrypoint/database/convert_pdf.py
+++ b/src/bluesearch/entrypoint/database/convert_pdf.py
@@ -156,6 +156,6 @@ def run(
         n_bytes = fh_xml.write(xml_content)
     logger.info("Wrote %d bytes to %s", n_bytes, output_xml_path.resolve().as_uri())
 
-    logger.info("Success.")
+    logger.info("PDF conversion done")
 
     return 0

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -1,5 +1,8 @@
 """Initialization of the database."""
 import argparse
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -43,6 +43,7 @@ def run(
     Parameter description and potential defaults are documented inside of the
     `get_parser` function.
     """
+    logger.info("Importing dependencies")
     import sqlalchemy
 
     from bluesearch.entrypoint.database.schemas import schema_articles, schema_sentences
@@ -66,3 +67,5 @@ def run(
     # Construction
     with engine.begin() as connection:
         metadata.create_all(connection)
+
+    logger.info("Done")

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -20,7 +20,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         argument.
     """
     parser.formatter_class = argparse.RawDescriptionHelpFormatter
-    description = """Initialize a database."""
+    parser.description = "Initialize a database."
 
     parser.add_argument(
         "db_url",

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -80,6 +80,6 @@ def run(
     with engine.begin() as connection:
         metadata.create_all(connection)
 
-    logger.info("Done")
+    logger.info("Initialization done")
 
     return 0

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -19,7 +19,6 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         The initialised argument parser. The same object as the `parser`
         argument.
     """
-    parser.formatter_class = argparse.RawDescriptionHelpFormatter
     parser.description = "Initialize a database."
 
     parser.add_argument(

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -5,11 +5,23 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """Create a parser."""
-    parser = argparse.ArgumentParser(
-        description="Initialize.",
-    )
+def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Initialise the argument parser for the init subcommand.
+
+    Parameters
+    ----------
+    parser
+        The argument parser to initialise.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The initialised argument parser. The same object as the `parser`
+        argument.
+    """
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    description = """Initialize a database."""
+
     parser.add_argument(
         "db_url",
         type=str,

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -49,7 +49,7 @@ def run(
     *,
     db_url: str,
     db_type: str,
-) -> None:
+) -> int:
     """Initialize database.
 
     Parameter description and potential defaults are documented inside of the
@@ -81,3 +81,5 @@ def run(
         metadata.create_all(connection)
 
     logger.info("Done")
+
+    return 0

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 
 from bluesearch.entrypoint.database import add, convert_pdf, init, parse
 
-Cmd = namedtuple("Cmd", ["name", "help", "init_parser", "run"])
+Cmd = namedtuple("Cmd", ["help", "init_parser", "run"])
 
 
 def _setup_logging(logging_level: int) -> None:
@@ -33,32 +33,28 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Database management utilities")
 
     # Define all commands, order matters (--help)
-    cmds = [
-        Cmd(
-            name="add",
+    cmds = {
+        "add": Cmd(
             help="Add parsed files to the database.",
             init_parser=add.init_parser,
             run=add.run,
         ),
-        Cmd(
-            name="convert-pdf",
+        "convert-pdf": Cmd(
             help="Convert a PDF file to a TEI XML file.",
             init_parser=convert_pdf.init_parser,
             run=convert_pdf.run,
         ),
-        Cmd(
-            name="init",
+        "init": Cmd(
             help="Initialize a database.",
             init_parser=init.init_parser,
             run=init.run,
         ),
-        Cmd(
-            name="parse",
+        "parse": Cmd(
             help="Parse raw files.",
             init_parser=parse.init_parser,
             run=parse.run,
         ),
-    ]
+    }
 
     # Create a verbosity parser (it will be a parent of all subparsers)
     verbosity_parser = argparse.ArgumentParser(
@@ -77,10 +73,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     # Initialize subparsers
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for cmd in cmds:
+    for cmd_name, cmd in cmds.items():
         cmd.init_parser(
             subparsers.add_parser(
-                cmd.name,
+                cmd_name,
                 help=cmd.help,
                 parents=[verbosity_parser],
             )
@@ -102,6 +98,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     _setup_logging(logging_level_map[verbose])
 
     # Run logic
-    chosen_cmd = [cmd for cmd in cmds if cmd.name == command][0]
-
-    return chosen_cmd.run(**kwargs)
+    return cmds[command].run(**kwargs)

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -28,7 +28,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "-v",
         "--verbose",
         help="Controls the verbosity",
-        action="store_true",
+        action="count",
+        default=0,
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -74,11 +75,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     kwargs = vars(args)
     command = kwargs.pop("command")
-    verbose = kwargs.pop("verbose")
+    verbose = min(kwargs.pop("verbose"), 2)
 
     # Setup logging
+    logging_level_map = {
+        0: logging.WARNING,
+        1: logging.INFO,
+        2: logging.DEBUG,
+    }
+
     root_logger = logging.getLogger()
-    root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
+    root_logger.setLevel(logging_level_map[verbose])
     formatter = logging.Formatter("%(asctime)s - %(name)s - %(message)s")
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -83,7 +83,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Setup logging
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
-    root_logger.addHandler(logging.StreamHandler(sys.stdout))
+    formatter = logging.Formatter("%(asctime)s - %(name)s - %(message)s")
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+    root_logger.addHandler(handler)
 
     # Run logic
     return command_map[command](**kwargs)  # type: ignore

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -31,16 +31,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     using subparsers.
     """
     parser = argparse.ArgumentParser(description="Database management utilities")
-    parent_parser = argparse.ArgumentParser(
-        add_help=False,
-    )
-    parent_parser.add_argument(
-        "-v",
-        "--verbose",
-        help="Controls the verbosity",
-        action="count",
-        default=0,
-    )
 
     # Define all commands, order matters (--help)
     cmds = [
@@ -70,6 +60,21 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         ),
     ]
 
+    # Create a verbosity parser (it will be a parent of all subparsers)
+    verbosity_parser = argparse.ArgumentParser(
+        add_help=False,
+    )
+    verbosity_parser.add_argument(
+        "-v",
+        "--verbose",
+        help=(
+            "Controls the verbosity by setting the logging level. "
+            "Default: WARNING, -v: INFO, -vv: DEBUG"
+        ),
+        action="count",
+        default=0,
+    )
+
     # Initialize subparsers
     subparsers = parser.add_subparsers(dest="command", required=True)
     for cmd in cmds:
@@ -77,7 +82,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             subparsers.add_parser(
                 cmd.name,
                 help=cmd.help,
-                parents=[parent_parser],
+                parents=[verbosity_parser],
             )
         )
 

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -4,12 +4,8 @@ import logging
 import sys
 from typing import Optional, Sequence
 
-from bluesearch.entrypoint.database import (
-    add,
-    convert_pdf,
-    init,
-    parse
-)
+from bluesearch.entrypoint.database import add, convert_pdf, init, parse
+
 
 def _setup_logging(logging_level: int):
     root_logger = logging.getLogger()
@@ -24,15 +20,14 @@ def _setup_logging(logging_level: int):
 
     root_logger.addHandler(handler)
 
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     """Run CLI.
 
     This is the main entrypoint that defines different commands
     using subparsers.
     """
-    parser = argparse.ArgumentParser(
-        description="Database management utilities"
-    )
+    parser = argparse.ArgumentParser(description="Database management utilities")
     parent_parser = argparse.ArgumentParser(
         add_help=False,
     )
@@ -74,7 +69,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     parse.init_parser(parse_parser)
 
-
     command_map = {
         "add": add.run,
         "convert-pdf": convert_pdf.run,
@@ -96,7 +90,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         2: logging.DEBUG,
     }
     _setup_logging(logging_level_map[verbose])
-
 
     # Run logic
     return command_map[command](**kwargs)  # type: ignore

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -7,7 +7,7 @@ from typing import Optional, Sequence
 
 from bluesearch.entrypoint.database import add, convert_pdf, init, parse
 
-Cmd = namedtuple("Cmd", "name help init_parser run")
+Cmd = namedtuple("Cmd", ["name", "help", "init_parser", "run"])
 
 
 def _setup_logging(logging_level: int) -> None:

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -10,7 +10,7 @@ from bluesearch.entrypoint.database import add, convert_pdf, init, parse
 Cmd = namedtuple("Cmd", "name help init_parser run")
 
 
-def _setup_logging(logging_level: int):
+def _setup_logging(logging_level: int) -> None:
     root_logger = logging.getLogger()
 
     root_logger.setLevel(logging_level)

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -7,9 +7,8 @@ from typing import Optional, Sequence
 from bluesearch.entrypoint.database import (
         add,
         convert_pdf,
+        init,
 )
-from bluesearch.entrypoint.database.init import get_parser as get_parser_init
-from bluesearch.entrypoint.database.init import run as run_init
 from bluesearch.entrypoint.database.parse import get_parser as get_parser_parse
 from bluesearch.entrypoint.database.parse import run as run_parse
 
@@ -35,7 +34,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # Initialize subparsers
-    parser_init = get_parser_init()
     parser_parse = get_parser_parse()
 
     add_parser = subparsers.add_parser(
@@ -52,13 +50,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     )
     convert_pdf.init_parser(convert_pdf_parser)
 
-    subparsers.add_parser(
+    init_parser = subparsers.add_parser(
         "init",
-        description=parser_init.description,
-        help=parser_init.description,
-        parents=[parser_init, parent_parser],
-        add_help=False,
+        help="Initialize a database.""",
+        parents=[parent_parser],
     )
+    init.init_parser(init_parser)
+
     subparsers.add_parser(
         "parse",
         description=parser_parse.description,
@@ -70,7 +68,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     command_map = {
         "add": add.run,
         "convert-pdf": convert_pdf.run,
-        "init": run_init,
+        "init": init.run,
         "parse": run_parse,
     }
 

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -11,6 +11,18 @@ from bluesearch.entrypoint.database import (
     parse
 )
 
+def _setup_logging(logging_level: int):
+    root_logger = logging.getLogger()
+
+    root_logger.setLevel(logging_level)
+
+    fmt = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
+    formatter = logging.Formatter(fmt)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(formatter)
+
+    root_logger.addHandler(handler)
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     """Run CLI.
@@ -83,13 +95,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         1: logging.INFO,
         2: logging.DEBUG,
     }
+    _setup_logging(logging_level_map[verbose])
 
-    root_logger = logging.getLogger()
-    root_logger.setLevel(logging_level_map[verbose])
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(message)s")
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-    root_logger.addHandler(handler)
 
     # Run logic
     return command_map[command](**kwargs)  # type: ignore

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -99,4 +99,4 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Run logic
     chosen_cmd = [cmd for cmd in cmds if cmd.name == command][0]
 
-    return chosen_cmd.run(**kwargs)  # type: ignore
+    return chosen_cmd.run(**kwargs)

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -5,12 +5,11 @@ import sys
 from typing import Optional, Sequence
 
 from bluesearch.entrypoint.database import (
-        add,
-        convert_pdf,
-        init,
+    add,
+    convert_pdf,
+    init,
+    parse
 )
-from bluesearch.entrypoint.database.parse import get_parser as get_parser_parse
-from bluesearch.entrypoint.database.parse import run as run_parse
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -34,8 +33,6 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # Initialize subparsers
-    parser_parse = get_parser_parse()
-
     add_parser = subparsers.add_parser(
         "add",
         help="Add parsed files to the database.",
@@ -52,24 +49,24 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     init_parser = subparsers.add_parser(
         "init",
-        help="Initialize a database.""",
+        help="Initialize a database.",
         parents=[parent_parser],
     )
     init.init_parser(init_parser)
 
-    subparsers.add_parser(
+    parse_parser = subparsers.add_parser(
         "parse",
-        description=parser_parse.description,
-        help=parser_parse.description,
-        parents=[parser_parse, parent_parser],
-        add_help=False,
+        help="Parse raw files.",
+        parents=[parent_parser],
     )
+    parse.init_parser(parse_parser)
+
 
     command_map = {
         "add": add.run,
         "convert-pdf": convert_pdf.run,
         "init": init.run,
-        "parse": run_parse,
+        "parse": parse.run,
     }
 
     # Do parsing

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -1,6 +1,7 @@
 """Module implementing the high level CLI logic."""
 import argparse
 import logging
+import sys
 from typing import Optional, Sequence
 
 from bluesearch.entrypoint.database import convert_pdf
@@ -82,6 +83,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # Setup logging
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO if verbose else logging.WARNING)
+    root_logger.addHandler(logging.StreamHandler(sys.stdout))
 
     # Run logic
     return command_map[command](**kwargs)  # type: ignore

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -4,9 +4,10 @@ import logging
 import sys
 from typing import Optional, Sequence
 
-from bluesearch.entrypoint.database import convert_pdf
-from bluesearch.entrypoint.database.add import get_parser as get_parser_add
-from bluesearch.entrypoint.database.add import run as run_add
+from bluesearch.entrypoint.database import (
+        add,
+        convert_pdf,
+)
 from bluesearch.entrypoint.database.init import get_parser as get_parser_init
 from bluesearch.entrypoint.database.init import run as run_init
 from bluesearch.entrypoint.database.parse import get_parser as get_parser_parse
@@ -34,17 +35,23 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     # Initialize subparsers
-    parser_add = get_parser_add()
     parser_init = get_parser_init()
     parser_parse = get_parser_parse()
 
-    subparsers.add_parser(
+    add_parser = subparsers.add_parser(
         "add",
-        description=parser_add.description,
-        help=parser_add.description,
-        parents=[parser_add, parent_parser],
-        add_help=False,
+        help="Add parsed files to the database.",
+        parents=[parent_parser],
     )
+    add.init_parser(add_parser)
+
+    convert_pdf_parser = subparsers.add_parser(
+        "convert-pdf",
+        help="Convert a PDF file to a TEI XML file.",
+        parents=[parent_parser],
+    )
+    convert_pdf.init_parser(convert_pdf_parser)
+
     subparsers.add_parser(
         "init",
         description=parser_init.description,
@@ -59,15 +66,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         parents=[parser_parse, parent_parser],
         add_help=False,
     )
-    convert_pdf_parser = subparsers.add_parser(
-        "convert-pdf",
-        help="Convert a PDF file to a TEI XML file.",
-        parents=[parent_parser],
-    )
-    convert_pdf.init_parser(convert_pdf_parser)
 
     command_map = {
-        "add": run_add,
+        "add": add.run,
         "convert-pdf": convert_pdf.run,
         "init": run_init,
         "parse": run_parse,

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -42,7 +42,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         default=0,
     )
 
-    # Define all commands
+    # Define all commands, order matters (--help)
     cmds = [
         Cmd(
             name="add",

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -13,14 +13,16 @@ Cmd = namedtuple("Cmd", ["help", "init_parser", "run"])
 def _setup_logging(logging_level: int) -> None:
     root_logger = logging.getLogger()
 
+    # Logging level
     root_logger.setLevel(logging_level)
 
+    # Formatter
     fmt = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
     formatter = logging.Formatter(fmt)
 
+    # Handler
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
-
     root_logger.addHandler(handler)
 
 

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -49,7 +49,6 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         The initialised argument parser. The same object as the `parser`
         argument.
     """
-    parser.formatter_class = argparse.RawDescriptionHelpFormatter
     parser.description = "Parse one or several articles."
 
     parser.add_argument(

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -50,7 +50,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         argument.
     """
     parser.formatter_class = argparse.RawDescriptionHelpFormatter
-    parser.description="Parse one or several articles."
+    parser.description = "Parse one or several articles."
 
     parser.add_argument(
         "input_type",

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -146,6 +146,6 @@ def run(
                 f'Failed parsing file "{input_path}":\n {e}', category=RuntimeWarning
             )
 
-    logger.info("Done")
+    logger.info("Parsing done")
 
     return 0

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -35,11 +35,23 @@ from bluesearch.database.article import (
 logger = logging.getLogger(__name__)
 
 
-def get_parser() -> argparse.ArgumentParser:
-    """Create a parser."""
-    parser = argparse.ArgumentParser(
-        description="Parse one or several articles.",
-    )
+def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Initialise the argument parser for the parse subcommand.
+
+    Parameters
+    ----------
+    parser
+        The argument parser to initialise.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The initialised argument parser. The same object as the `parser`
+        argument.
+    """
+    parser.formatter_class = argparse.RawDescriptionHelpFormatter
+    parser.description="Parse one or several articles."
+
     parser.add_argument(
         "input_type",
         type=str,

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -107,7 +107,7 @@ def run(
     input_type: str,
     input_path: Path,
     output_dir: Path,
-) -> None:
+) -> int:
     """Parse one or several articles.
 
     Parameter description and potential defaults are documented inside of the
@@ -147,3 +147,5 @@ def run(
             )
 
     logger.info("Done")
+
+    return 0

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -17,6 +17,7 @@
 """Parsing articles."""
 import argparse
 import json
+import logging
 import warnings
 from pathlib import Path
 from typing import Iterable, Iterator
@@ -30,6 +31,8 @@ from bluesearch.database.article import (
     PMCXMLParser,
     PubMedXMLParser,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_parser() -> argparse.ArgumentParser:

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -114,6 +114,8 @@ def run(
     output_dir.mkdir(exist_ok=True)
 
     for input_path in inputs:
+        logger.info(f"Parsing {input_path.name}")
+
         try:
             parsers = iter_parsers(input_type, input_path)
 
@@ -131,3 +133,5 @@ def run(
             warnings.warn(
                 f'Failed parsing file "{input_path}":\n {e}', category=RuntimeWarning
             )
+
+    logger.info("Done")

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -84,7 +84,7 @@ def setup_backend(request, tmp_path):
         raise ValueError
 
 
-def test_bbs_database(tmp_path, setup_backend, jsons_path):
+def test_bbs_database(tmp_path, setup_backend, jsons_path, caplog):
     # Parameters
     db_type, db_url = setup_backend
 
@@ -106,6 +106,7 @@ def test_bbs_database(tmp_path, setup_backend, jsons_path):
         "init",
         str(db_url),
         f"--db-type={db_type}",
+        "-v",
     ]
     main(args_and_opts_init)
 
@@ -116,6 +117,7 @@ def test_bbs_database(tmp_path, setup_backend, jsons_path):
             "cord19-json",
             str(input_path),
             str(parsed_files_dir),
+            "-v",
         ]
         main(args_and_opts_parse)
 
@@ -125,6 +127,7 @@ def test_bbs_database(tmp_path, setup_backend, jsons_path):
         str(db_url),
         str(parsed_files_dir),
         f"--db-type={db_type}",
+        "-v",
     ]
     main(args_and_opts_add)
 
@@ -139,3 +142,11 @@ def test_bbs_database(tmp_path, setup_backend, jsons_path):
     (n_rows,) = engine.execute(query).fetchone()  # type: ignore
 
     assert n_rows == n_files > 0
+
+    # Check logging
+    expected_messages = {
+        "Initialization done",
+        "Parsing done",
+        "Adding done",
+    }
+    assert expected_messages.issubset({r.message for r in caplog.records})

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -3,6 +3,6 @@ import subprocess
 import pytest
 
 
-@pytest.mark.parametrize("command", ["add", "init"])
+@pytest.mark.parametrize("command", ["add", "convert-pdf", "init", "parse"])
 def test_commands_work(command):
     subprocess.check_call(["bbs_database", command, "--help"])

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -5,4 +5,4 @@ import pytest
 
 @pytest.mark.parametrize("command", ["add", "convert-pdf", "init", "parse"])
 def test_commands_work(command):
-    subprocess.check_call(["bbs_database", command, "--help"])
+    subprocess.run(["bbs_database", command, "--help"], check=True)

--- a/tests/unit/entrypoint/test_entrypoint_installation.py
+++ b/tests/unit/entrypoint/test_entrypoint_installation.py
@@ -35,4 +35,4 @@ import pytest
     ],
 )
 def test_entrypoint(entrypoint_name):
-    subprocess.check_call([entrypoint_name, "--help"])
+    subprocess.run([entrypoint_name, "--help"], check=True)


### PR DESCRIPTION
Closes #486, closes #488, closes #487, closes #421

## Description
* Introduced `-v` and `-vv` flag in all subcommands (using a parent parser) that controls the logging level
* Using `init_parser` everywhere which is a function that modifies the parser in place
* Make CLI creation "semi-dynamic" (inspired by discussion with @Stannislav)

## How to test?
Each of the `add`, `init`, `parse`, `convert-pdf` supports an optional flag `-v` or `-vv` controlling the verbosity.

Internally, this is the mapping between the logging level and the CLI flag:
```
nothing -> logging.WARNING
-v      -> logging.INFO
-vv     -> logging.DEBUG
```

For example

```
bbs_database init -v temp_db.sqlite

```


# To discuss
* Feel free to propose a different formatting of the LogRecords
* Currently, we only have a standard output handler, however, we can add more

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
