### PR TITLE
Improve JATS Parsing

### DIFF
--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -186,7 +186,12 @@ class JATSXMLParser(ArticleParser):
         """
         abstract_pars = self.content.findall("./front/article-meta/abstract//p")
         for paragraph in abstract_pars:
-            yield self._element_to_str(paragraph)
+            # Check if paragraph has paragraphs as children
+            if not paragraph.findall(".//p"):
+                text = self._element_to_str(paragraph)
+                # Check if text is not empty
+                if text:
+                    yield text
 
     @property
     def paragraphs(self) -> Generator[tuple[str, str], None, None]:
@@ -207,7 +212,7 @@ class JATSXMLParser(ArticleParser):
         # with the section name "Caption".
         caption_p = self.content.findall("./body//caption/p")
         # Acknowledgements are removed because not useful.
-        acknowledg_p = self.content.findall("./back/ack/p")
+        acknowledg_p = self.content.findall("./back/ack//p")
 
         exclude_list = abstract_p + caption_p + acknowledg_p
 

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -242,8 +242,8 @@ class JATSXMLParser(ArticleParser):
         # Table captions
         tables = self.content.findall("./body//table-wrap")
         for table in tables:
-            caption_elements = table.findall("./caption/p") or table.findall(
-                "./caption/title"
+            caption_elements = table.findall(".//caption/p") or table.findall(
+                ".//caption/title"
             )
             if caption_elements is None:
                 continue

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -185,9 +185,11 @@ class JATSXMLParser(ArticleParser):
             The paragraphs of the article abstract.
         """
         abstract_pars = self.content.findall("./front/article-meta/abstract//p")
+        children_p = []
         for paragraph in abstract_pars:
-            # Check if paragraph has paragraphs as children
-            if not paragraph.findall(".//p"):
+            # Check if paragraph is not child of another paragraph
+            children_p += paragraph.findall(".//p")
+            if paragraph not in children_p:
                 text = self._element_to_str(paragraph)
                 # Check if text is not empty
                 if text:
@@ -217,11 +219,13 @@ class JATSXMLParser(ArticleParser):
         exclude_list = abstract_p + caption_p + acknowledg_p
 
         # Paragraphs of text body
+        children_p = []
         section_dirs = self.get_paragraphs_sections_mapping()
         for paragraph in self.content.findall(".//p"):
             # Check that paragraph is not in the exclude list and
-            # that paragraph does not have paragraph(s) as children.
-            if paragraph not in exclude_list and not paragraph.findall(".//p"):
+            # that paragraph is not child of another paragraph.
+            if paragraph not in exclude_list and paragraph not in children_p:
+                children_p += paragraph.findall(".//p")
                 text = self._element_to_str(paragraph)
                 section_title = ""
                 if paragraph in section_dirs:

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import html
 import string
+import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
@@ -367,7 +368,7 @@ class JATSXMLParser(ArticleParser):
             text_parts.append(self._element_to_str(sub_element))
             # don't forget the text after the sub-element
             text_parts.append(html.unescape(sub_element.tail or ""))
-        return "".join(text_parts).replace("\xa0", " ").replace("\u2009", " ").strip()
+        return unicodedata.normalize("NFKC", "".join(text_parts)).strip()
 
     def _element_to_str(self, element: Element | None) -> str:
         """Convert an element and all its contents to a string.

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -112,7 +112,7 @@ class TestJATSXMLArticleParser:
         assert inspect.isgenerator(paragraphs)
         paragraphs = tuple(paragraphs)
         assert len(paragraphs) == 7 + 1 + 2  # for paragraph, caption, table
-        # (one caption is empty)
+        # There are 3 caption but one is empty
 
         for i, paragraph in enumerate(paragraphs):
             assert isinstance(paragraph, tuple)

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -111,7 +111,8 @@ class TestJATSXMLArticleParser:
         paragraphs = jats_xml_parser.paragraphs
         assert inspect.isgenerator(paragraphs)
         paragraphs = tuple(paragraphs)
-        assert len(paragraphs) == 7 + 1 + 3  # for paragraph, caption, table
+        assert len(paragraphs) == 7 + 1 + 2  # for paragraph, caption, table
+        # (one caption is empty)
 
         for i, paragraph in enumerate(paragraphs):
             assert isinstance(paragraph, tuple)


### PR DESCRIPTION
Fixes #496, #425 and #429.

## Description

The PR improves JATS Parsing:
- Do not `yield` empty paragraphs
- Replace `\xa0` and `\u2009` by spaces (check  abstract of `/raid/projects/bbs/pmc/comm_use/Trauma_Surg_Acute_Care_Open/PMC6045722.nxml` for concrete illustration)
- Replace double-slash by single-slash when possible. However, the structure is always changing so it is not possible to put single slash everywhere (for example the number of sections varies `./body/sec/sec/.../sec/p/`)
- For paragraphs into paragraphs, concatenate all children paragraphs into one big one. (still to be discussed)

## Checklist

- [X] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
