### PR TITLE
Speed up tests + avoid OOM issues

### DIFF
--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 import sqlalchemy
 
@@ -23,7 +25,12 @@ def engine_sqlite(tmp_path):
     return eng
 
 
-def test_sqlite_cord19(engine_sqlite, tmp_path):
+def test_sqlite_cord19(engine_sqlite, tmp_path, monkeypatch, model_entities):
+    # Reuse a spacy model fixture
+    monkeypatch.setattr(
+        "bluesearch.utils.load_spacy_model", Mock(return_value=model_entities)
+    )
+
     parsed_dir = tmp_path / "parsed_files"
     parsed_dir.mkdir()
     n_files = 3

--- a/tests/unit/entrypoint/database/test_add.py
+++ b/tests/unit/entrypoint/database/test_add.py
@@ -114,7 +114,12 @@ def test_no_articles(tmp_path):
         main(["add", "test.db", str(parsed_dir)])
 
 
-def test_no_sentences(tmp_path, engine_sqlite):
+def test_no_sentences(tmp_path, engine_sqlite, monkeypatch, model_entities):
+    # Reuse a spacy model fixture
+    monkeypatch.setattr(
+        "bluesearch.utils.load_spacy_model", Mock(return_value=model_entities)
+    )
+
     parsed_dir = tmp_path / "parsed_files"
     parsed_dir.mkdir()
 

--- a/tests/unit/entrypoint/test_embeddings.py
+++ b/tests/unit/entrypoint/test_embeddings.py
@@ -131,7 +131,10 @@ def test_send_through(
         ),
     ],
 )
-@pytest.mark.parametrize("start_method", ["forkserver", "spawn"])
+@pytest.mark.parametrize(
+    "start_method",
+    ["forkserver", pytest.param("spawn", marks=pytest.mark.skip("Not the default"))],
+)
 @pytest.mark.parametrize("model", ["SBioBERT", "SBERT"])
 def test_mp_real(
     tmpdir,


### PR DESCRIPTION
Fixes #489 and fixes #446.

## Description
List of all "optimizations":
* When testing, don't load a large spacy model during `bbs_database add`. This should also eliminate OOM issues.
* Skip `spawn` multiprocessing method in tests of `compute_embeddings`.  The default is `forkserver` and that one we don't skip. I wanted to do more cleanup here, however, I gave up.
 
## Performance comparison

```
pytest -m ""  # run on my laptop
```

* `master`: 190s
* this PR: 152s

## Other ideas?
If you have some ideas how a minimal change in the source code could lead to significant speedups please feel free to share them.
