### PR TITLE
Postgres integration + experiments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ langdetect==1.0.9
 mashumaro==2.7
 numpy==1.21.0
 pandas==1.3.0
+pg8000==1.23.0
 python-dotenv==0.18.0
 requests==2.26.0
 scikit-learn==0.24.2

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ INSTALL_REQUIRES = [
     "pandas>=1",
     # Serialization framework on top of dataclasses, e.g. 'Article' to and from JSON.
     "mashumaro",
+    "pg8000",
     "python-dotenv",
     "requests",
     "scikit-learn",

--- a/src/bluesearch/entrypoint/database/add.py
+++ b/src/bluesearch/entrypoint/database/add.py
@@ -60,7 +60,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--db-type",
         default="sqlite",
         type=str,
-        choices=("mariadb", "mysql", "sqlite"),
+        choices=("mariadb", "mysql", "postgres", "sqlite"),
         help="Type of the database.",
     )
     return parser
@@ -89,6 +89,9 @@ def run(
 
     elif db_type in {"mariadb", "mysql"}:
         engine = sqlalchemy.create_engine(f"mysql+pymysql://{db_url}")
+
+    elif db_type == "postgres":
+        engine = sqlalchemy.create_engine(f"postgresql+pg8000://{db_url}")
 
     else:
         # This branch never reached because of `choices` in `argparse`

--- a/src/bluesearch/entrypoint/database/init.py
+++ b/src/bluesearch/entrypoint/database/init.py
@@ -38,7 +38,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--db-type",
         default="sqlite",
         type=str,
-        choices=("mariadb", "mysql", "sqlite"),
+        choices=("mariadb", "mysql", "postgres", "sqlite"),
         help="Type of the database.",
     )
     return parser
@@ -64,6 +64,9 @@ def run(
 
     elif db_type in {"mariadb", "mysql"}:
         engine = sqlalchemy.create_engine(f"mysql+pymysql://{db_url}")
+
+    elif db_type == "postgres":
+        engine = sqlalchemy.create_engine(f"postgresql+pg8000://{db_url}")
 
     else:
         # This branch never reached because of `choices` in `argparse`

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -2,6 +2,7 @@ import subprocess
 import time
 
 import docker
+import pg8000
 import pytest
 import sqlalchemy
 from sqlalchemy.exc import OperationalError
@@ -31,6 +32,7 @@ def get_docker_client():
         "sqlite",
         # "mysql",  # not used in production and slows down CI
         "mariadb",
+        "postgres",
     ]
 )
 def setup_backend(request, tmp_path):
@@ -39,17 +41,55 @@ def setup_backend(request, tmp_path):
         db_url = tmp_path / "db.sqlite"
         yield "sqlite", str(db_url)
 
-    elif backend in {"mariadb", "mysql"}:
+    elif backend in {"mariadb", "mysql", "postgres"}:
+        # Check if docker client ready
         client = get_docker_client()
 
         if client is None:
             pytest.skip("Docker daemon is not running")
 
+        # Define backend specific logic
+        env_map = {
+            "mariadb": "MYSQL_ROOT_PASSWORD",
+            "mysql": "MYSQL_ROOT_PASSWORD",
+            "postgres": "POSTGRES_PASSWORD",
+        }
+
+        driver_map = {
+            "mariadb": "mysql+pymysql",
+            "mysql": "mysql+pymysql",
+            "postgres": "postgresql+pg8000",
+        }
+
+        port_map = {
+            "mariadb": 3306,
+            "mysql": 3306,
+            "postgres": 5432,
+        }
+
+        user_map = {
+            "mariadb": "root",
+            "mysql": "root",
+            "postgres": "postgres",
+        }
+
+        show_databases_map = {
+            "mariadb": "show databases",
+            "mysql": "show databases",
+            "postgres": "select datname from pg_database;",
+        }
+
+        create_database_map = {
+            "mariadb": "create database test",
+            "mysql": "create database test",
+            "postgres": "create database test;",
+        }
+
         port = 22346
         container = client.containers.run(
             image=f"{backend}:latest",
-            environment={"MYSQL_ROOT_PASSWORD": "my-secret-pw"},
-            ports={"3306/tcp": port},
+            environment={f"{env_map[backend]}": "my-secret-pw"},
+            ports={f"{port_map[backend]}/tcp": port},
             detach=True,
             auto_remove=True,
         )
@@ -60,19 +100,19 @@ def setup_backend(request, tmp_path):
         while time.perf_counter() - start < max_waiting_time:
             try:
                 engine = sqlalchemy.create_engine(
-                    f"mysql+pymysql://root:my-secret-pw@127.0.0.1:{port}/"
+                    f"{driver_map[backend]}://{user_map[backend]}:my-secret-pw@127.0.0.1:{port}/"
                 )
                 # Container ready?
-                engine.execute("show databases")
+                engine.execute(show_databases_map[backend]).fetchall()
                 break
-            except OperationalError:
+            except (OperationalError, pg8000.core.struct.error):
                 # Container not ready, pause and then try again
                 time.sleep(0.1)
                 continue
         else:
             raise TimeoutError("Could not spawn the container.")
 
-        engine.execute("create database test")
+        engine.execute(create_database_map[backend])
         engine.dispose()
 
         yield backend, f"root:my-secret-pw@127.0.0.1:{port}/test",

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -109,6 +109,7 @@ def setup_backend(request, tmp_path):
                 InterfaceError,
                 OperationalError,
                 pg8000.core.struct.error,
+                pg8000.dbapi.ProgrammingError,
             ):
                 # Container not ready, pause and then try again
                 time.sleep(0.1)

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -180,7 +180,7 @@ def test_bbs_database(tmp_path, setup_backend, jsons_path, caplog):
         engine = sqlalchemy.create_engine(f"mysql+pymysql://{db_url}")
 
     elif db_type == "postgres":
-        engine = sqlalchemy.create_engine(f"postgres+pg8000//{db_url}")
+        engine = sqlalchemy.create_engine(f"postgresql+pg8000://{db_url}")
 
 
     query = "SELECT COUNT(*) FROM articles"

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -86,9 +86,10 @@ def setup_backend(request, tmp_path):
         }
 
         port = 22346
+        pw = "my-secret-pw"
         container = client.containers.run(
             image=f"{backend}:latest",
-            environment={f"{env_map[backend]}": "my-secret-pw"},
+            environment={f"{env_map[backend]}": pw},
             ports={f"{port_map[backend]}/tcp": port},
             detach=True,
             auto_remove=True,
@@ -96,13 +97,10 @@ def setup_backend(request, tmp_path):
 
         max_waiting_time = 2 * 60
         start = time.perf_counter()
-
+        url = f"{driver_map[backend]}://{user_map[backend]}:{pw}@127.0.0.1:{port}/"
         while time.perf_counter() - start < max_waiting_time:
             try:
-                engine = sqlalchemy.create_engine(
-                    f"{driver_map[backend]}://{user_map[backend]}:my-secret-pw@127.0.0.1:{port}/",
-                    isolation_level="AUTOCOMMIT",
-                )
+                engine = sqlalchemy.create_engine(url, isolation_level="AUTOCOMMIT")
                 # Container ready?
                 engine.execute(show_databases_map[backend]).fetchall()
                 break

--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -30,8 +30,8 @@ def get_docker_client():
 @pytest.fixture(
     params=[
         "sqlite",
-        "mysql",  # not used in production and slows down CI
-        "mariadb",
+        # "mysql",  # not used in production and slows down CI
+        # "mariadb", # not used in production and slows down CI
         "postgres",
     ]
 )
@@ -130,6 +130,7 @@ def setup_backend(request, tmp_path):
         raise ValueError
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_bbs_database(tmp_path, setup_backend, jsons_path, caplog):
     # Parameters
     db_type, db_url = setup_backend

--- a/tests/unit/database/test_cord_19.py
+++ b/tests/unit/database/test_cord_19.py
@@ -96,6 +96,7 @@ def test_mark_bad_sentences(fake_sqlalchemy_engine):
 class TestDatabaseCreation:
     """Tests the creation of the Database"""
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_database_content(self, real_sqlalchemy_engine):
         """Tests that the two tables expected has been created."""
         inspector = sqlalchemy.inspect(real_sqlalchemy_engine)

--- a/tests/unit/test_embedding_models.py
+++ b/tests/unit/test_embedding_models.py
@@ -41,6 +41,7 @@ from bluesearch.embedding_models import (
 GPU_IS_AVAILABLE = torch.cuda.is_available()
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestEmbeddingModels:
     """The included tests do not use real models."""
 
@@ -94,7 +95,6 @@ class TestEmbeddingModels:
         assert embedding.shape == ((768,) if n_sentences == 1 else (n_sentences, 768))
         senttrans_model.encode.assert_called_once()
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     @pytest.mark.parametrize(
         "backend", ["TfidfVectorizer", "CountVectorizer", "HashingVectorizer"]
     )

--- a/tests/unit/test_embedding_models.py
+++ b/tests/unit/test_embedding_models.py
@@ -94,6 +94,7 @@ class TestEmbeddingModels:
         assert embedding.shape == ((768,) if n_sentences == 1 else (n_sentences, 768))
         senttrans_model.encode.assert_called_once()
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     @pytest.mark.parametrize(
         "backend", ["TfidfVectorizer", "CountVectorizer", "HashingVectorizer"]
     )


### PR DESCRIPTION
This PR adds the `postgres` backend to the `init` and `add` entrypoints. It also adds it to the integration test `tests/integration/test_bbs_database.py`. 

Closes #499 
Fixes #527.

## Description
Why is the CI failing? There is this `PytestUnraisableExceptionWarning` ([docs](https://docs.pytest.org/en/6.2.x/reference.html#pytest.PytestUnraisableExceptionWarning)). There are several ways how to handle this:
- Figure out the core reason why it is raised and fix it
- Ignore it locally with `@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")` - already done elsewhere in our sourc ecode
- Ignore it globally with `pytest -p no:unraisableexception`
- Abandon this test / change it so that no exception occurs (e.g. trying a different driver than `pg8000`?)



## How to test?
```
pytest -p no:unraisableexception tests/integration/test_bbs_database.py 
```

## Checklist

- [ ] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
