### PR TITLE
Test API docs in tox + CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [lint, docs, check-packaging]
+        tox-env: [lint, docs, check-apidoc, check-packaging]
     steps:
       - name: Cancel previous workflows that are still running
         uses: styfle/cancel-workflow-action@0.8.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,6 +28,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 project = "Blue Brain Search"
 author = "Blue Brain Project"
+version = bluesearch.__version__
 
 # -- General configuration ---------------------------------------------------
 
@@ -54,19 +55,23 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-#
 html_theme = "sphinx-bluebrain-theme"
 html_title = "Blue Brain Search"
-html_theme_options = {"metadata_distribution": "bluesearch"}
-version = bluesearch.__version__
-
+html_theme_options = {
+    "metadata_distribution": "bluesearch",
+    "repo_name": "bluesearch",
+    "repo_url": "https://github.com/BlueBrain/Search",
+}
+# If true, the reST sources are included in the HTML build as _sources/name.
+html_copy_source = False
+# If true (and html_copy_source is true as well), links to the reST sources
+# will be added to the sidebar.
+html_show_sourcelink = False
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
-
-# Do not mention module names
+# A boolean that decides whether module names are prepended to all object names
+# (for object types where a “module” of some kind is defined), e.g. for
+# py:function directives.
 add_module_names = False
-
-# Blue brain theme specific
-html_show_sourcelink = False

--- a/docs/source/api/bluesearch.database.article.rst
+++ b/docs/source/api/bluesearch.database.article.rst
@@ -1,5 +1,5 @@
 bluesearch.database.article module
-========================================
+==================================
 
 .. automodule:: bluesearch.database.article
    :members:

--- a/docs/source/api/bluesearch.database.identifiers.rst
+++ b/docs/source/api/bluesearch.database.identifiers.rst
@@ -1,0 +1,7 @@
+bluesearch.database.identifiers module
+======================================
+
+.. automodule:: bluesearch.database.identifiers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.database.pdf.rst
+++ b/docs/source/api/bluesearch.database.pdf.rst
@@ -1,0 +1,7 @@
+bluesearch.database.pdf module
+==============================
+
+.. automodule:: bluesearch.database.pdf
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.database.rst
+++ b/docs/source/api/bluesearch.database.rst
@@ -9,7 +9,9 @@ Submodules
 
    bluesearch.database.article
    bluesearch.database.cord_19
+   bluesearch.database.identifiers
    bluesearch.database.mining_cache
+   bluesearch.database.pdf
    bluesearch.database.topic
 
 Module contents

--- a/docs/source/api/bluesearch.database.topic.rst
+++ b/docs/source/api/bluesearch.database.topic.rst
@@ -1,5 +1,5 @@
 bluesearch.database.topic module
-========================================
+================================
 
 .. automodule:: bluesearch.database.topic
    :members:

--- a/docs/source/api/bluesearch.entrypoint.create_database.rst
+++ b/docs/source/api/bluesearch.entrypoint.create_database.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.create\_database module
+=============================================
+
+.. automodule:: bluesearch.entrypoint.create_database
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.add.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.add.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.add module
+=========================================
+
+.. automodule:: bluesearch.entrypoint.database.add
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.convert_pdf.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.convert_pdf.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.convert\_pdf module
+==================================================
+
+.. automodule:: bluesearch.entrypoint.database.convert_pdf
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.init.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.init.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.init module
+==========================================
+
+.. automodule:: bluesearch.entrypoint.database.init
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.parent.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.parent.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.parent module
+============================================
+
+.. automodule:: bluesearch.entrypoint.database.parent
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.parse.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.parse.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.parse module
+===========================================
+
+.. automodule:: bluesearch.entrypoint.database.parse
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.rst
@@ -1,0 +1,23 @@
+bluesearch.entrypoint.database package
+======================================
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   bluesearch.entrypoint.database.add
+   bluesearch.entrypoint.database.convert_pdf
+   bluesearch.entrypoint.database.init
+   bluesearch.entrypoint.database.parent
+   bluesearch.entrypoint.database.parse
+   bluesearch.entrypoint.database.schemas
+
+Module contents
+---------------
+
+.. automodule:: bluesearch.entrypoint.database
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.database.schemas.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.schemas.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.schemas module
+=============================================
+
+.. automodule:: bluesearch.entrypoint.database.schemas
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.embedding_server.rst
+++ b/docs/source/api/bluesearch.entrypoint.embedding_server.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.embedding\_server module
+==============================================
+
+.. automodule:: bluesearch.entrypoint.embedding_server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.embeddings.rst
+++ b/docs/source/api/bluesearch.entrypoint.embeddings.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.embeddings module
+=======================================
+
+.. automodule:: bluesearch.entrypoint.embeddings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.mining_cache.rst
+++ b/docs/source/api/bluesearch.entrypoint.mining_cache.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.mining\_cache module
+==========================================
+
+.. automodule:: bluesearch.entrypoint.mining_cache
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.mining_server.rst
+++ b/docs/source/api/bluesearch.entrypoint.mining_server.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.mining\_server module
+===========================================
+
+.. automodule:: bluesearch.entrypoint.mining_server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.rst
+++ b/docs/source/api/bluesearch.entrypoint.rst
@@ -1,0 +1,31 @@
+bluesearch.entrypoint package
+=============================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   bluesearch.entrypoint.database
+
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   bluesearch.entrypoint.create_database
+   bluesearch.entrypoint.embedding_server
+   bluesearch.entrypoint.embeddings
+   bluesearch.entrypoint.mining_cache
+   bluesearch.entrypoint.mining_server
+   bluesearch.entrypoint.search_server
+
+Module contents
+---------------
+
+.. automodule:: bluesearch.entrypoint
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.entrypoint.search_server.rst
+++ b/docs/source/api/bluesearch.entrypoint.search_server.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.search\_server module
+===========================================
+
+.. automodule:: bluesearch.entrypoint.search_server
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/bluesearch.rst
+++ b/docs/source/api/bluesearch.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    bluesearch.database
+   bluesearch.entrypoint
    bluesearch.mining
    bluesearch.server
    bluesearch.widgets
@@ -22,7 +23,6 @@ Submodules
    bluesearch.search
    bluesearch.sql
    bluesearch.utils
-   bluesearch.version
 
 Module contents
 ---------------

--- a/docs/source/api/bluesearch.version.rst
+++ b/docs/source/api/bluesearch.version.rst
@@ -1,7 +1,0 @@
-bluesearch.version module
-=========================
-
-.. automodule:: bluesearch.version
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,8 @@ Legend
 
 Latest
 ======
+- |Add| run the tox env ``check-apidoc`` in CI
+- |Add| tox environments ``apidoc`` and ``check-apidoc``
 - |Add| option ``--dry-run`` for ``bbs_database parse`` to display files to
   parse without parsing them.
 - |Add| option ``--recursive`` for ``bbs_database parse`` to parse files

--- a/src/bluesearch/entrypoint/database/convert_pdf.py
+++ b/src/bluesearch/entrypoint/database/convert_pdf.py
@@ -99,9 +99,12 @@ def run(
     able to combine the functions in this way:
 
     >>> import argparse
-    >>> parser = init_parser(argparse.ArgumentParser())
-    >>> args = parser.parse_args()
-    >>> run(**vars(args))
+    >>> from bluesearch.entrypoint.database import convert_pdf
+    >>> parser = convert_pdf.init_parser(argparse.ArgumentParser())
+    >>> # replace with true values and uncomment
+    >>> argv = ["host", "port", "pdf_path", "xml_path"]
+    >>> # args = parser.parse_args(argv)
+    >>> # convert_pdf.run(**vars(args))
 
     This will run the convert-pdf subcommand implemented here as a standalone
     application.

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
 sources = setup.py src/bluesearch tests benchmarks data_and_models
-envlist = lint, py{37, 38, 39}, docs, check-packaging
+envlist = lint, py{37, 38, 39}, docs, check-apidoc check-packaging
 ; Enable PEP-517/518, https://tox.wiki/en/latest/config.html#conf-isolated_build
 isolated_build = true
 
@@ -78,6 +78,24 @@ commands =
     make doctest SPHINXOPTS=-W
     make html SPHINXOPTS=-W
 allowlist_externals = make
+
+[testenv:apidoc]
+skip_install = true
+allowlist_externals = rm
+deps =
+    sphinx
+commands =
+    rm -r docs/source/api
+    sphinx-apidoc -Tefo docs/source/api src/bluesearch src/bluesearch/version.py
+
+[testenv:check-apidoc]
+skip_install = true
+allowlist_externals = diff
+deps =
+    sphinx
+commands =
+    sphinx-apidoc -Tefo {envtmpdir} src/bluesearch src/bluesearch/version.py
+    diff {envtmpdir} docs/source/api
 
 [testenv:check-packaging]
 basepython = python3.7


### PR DESCRIPTION
Fixes #505 

This adds two new tox environments:
* `tox -e apidoc`
* `tox -e check-apidoc`

The first one generates the API docs the second one checks that the API docs are up-to-date.

I updated our CI to include the `check-apidoc` check.

A small change in `docs/conf.py` adds a link to the GitHub repo in the top banner of the docs.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
