### PR TITLE
Implement `bbs_database download` for biorxiv and medrxiv

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@
 
 Flask==2.0.1
 SQLAlchemy[mysql,pymysql]==1.4.21
+boto3==1.20.16
 catalogue==2.0.4
 cryptography==3.4.7
 defusedxml==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ PYTHON_REQUIRES = ">=3.7"
 INSTALL_REQUIRES = [
     "Flask",
     "SQLAlchemy[mysql,pymysql]",
+    "boto3",
     "catalogue>=2.0.3",  # see https://github.com/explosion/catalogue/issues/17
     # Required to encrypt mysql password; >= 3.2 to fix RSA decryption vulnerability
     "cryptography>=3.2",

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -36,8 +36,8 @@ def get_daterange_list(
 ) -> list[datetime]:
     """Retrieve list of datetimes between a start date and an end date (both inclusive).
 
-    If `delta=day` then we discard hours, minutes, seconds and miliseconds.
-    If `delta=month` then we discard days, hours, minutes, seconds and miliseconds.
+    If `delta=day` then we discard hours, minutes, seconds and milliseconds.
+    If `delta=month` then we discard days, hours, minutes, seconds and milliseconds.
 
     Parameters
     ----------

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -241,7 +241,7 @@ def download_articles(url_list: list[str], output_dir: Path) -> None:
             f.write(r.content)
 
 
-def download_articles_s3(
+def download_s3_articles(
     bucket: boto3.resources.base.ServiceResource,
     url_dict: dict[str, list[str]],
     output_dir: Path,

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import logging
 import re
-from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -202,16 +201,14 @@ def get_s3_urls(
     month_year_list = [date.strftime("%B_%Y") for date in date_list]
 
     # filtering objects using boto3
-    url_dict = defaultdict(list)
+    url_dict = {}
     for month_year in month_year_list:
         objects = bucket.objects.filter(
             Prefix=f"Current_Content/{month_year}",
             RequestPayer="requester",
         )
-        for obj in objects:
-            key = obj.key
-            if key.endswith(".meca"):
-                url_dict[month_year].append(key)
+
+        url_dict[month_year] = [obj.key for obj in objects if obj.key.endswith(".meca")]
 
     return url_dict
 

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -66,8 +66,8 @@ def get_daterange_list(
             current_date += timedelta(days=1)
 
     elif delta == "month":
-        start_date = datetime(start_date.year, start_date.month)
-        end_date = datetime(end_date.year, end_date.month)
+        start_date = datetime(start_date.year, start_date.month, 1)
+        end_date = datetime(end_date.year, end_date.month, 1)
 
         current_date = start_date
         while current_date <= end_date:

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -259,8 +259,8 @@ def download_articles_s3(
         Keys represent different months. Values represent lists of the
         actual `.meca` files.
     output_dir
-        Output directory to save the download. We assume that it already
-        exists.
+        Output directory to save the download. It will be automatically created
+        in case it does not exist.
     """
     s3_resource = boto3.resource("s3")
     bucket = s3_resource.Bucket(f"{source}-src-monthly")

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -217,7 +217,9 @@ def get_s3_urls(
             RequestPayer="requester",
         )
         for obj in objects:
-            url_dict[month_year].append(obj.key)
+            key = obj.key
+            if key.endswith(".meca"):
+                url_dict[month_year].append(key)
 
     return url_dict
 
@@ -272,4 +274,4 @@ def download_articles_s3(
         for url in url_list:
             output_path = parent_folder / url.split("/")[-1]
             logger.info(f"Downloading {url}")
-            bucket.download_file(url, str(output_path))
+            bucket.download_file(url, str(output_path), {'RequestPayer':'requester'})

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import boto3
 import requests
+from boto3.resources.base import ServiceResource
 
 logger = logging.getLogger(__name__)
 
@@ -167,7 +168,7 @@ def get_pubmed_urls(
 
 
 def get_s3_urls(
-    bucket: boto3.resources.base.ServiceResource,
+    bucket: ServiceResource,
     start_date: datetime,
     end_date: datetime | None = None,
 ) -> dict[str, list[str]]:
@@ -239,7 +240,7 @@ def download_articles(url_list: list[str], output_dir: Path) -> None:
 
 
 def download_s3_articles(
-    bucket: boto3.resources.base.ServiceResource,
+    bucket: ServiceResource,
     url_dict: dict[str, list[str]],
     output_dir: Path,
 ) -> None:

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -192,10 +192,6 @@ def get_s3_urls(
         actual `.meca` files.
 
     """
-    # checks
-    if end_date is None:
-        end_date = datetime.today()
-
     # generate November_2019, December_2019, ...
     date_list = get_daterange_list(
         start_date=start_date,

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -30,7 +30,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_daterange_list(
-        start_date: datetime, end_date: datetime | None = None, delta: str = "day",
+    start_date: datetime,
+    end_date: datetime | None = None,
+    delta: str = "day",
 ) -> list[datetime]:
     """Retrieve list of datetimes between a start date and an end date (both inclusive).
 
@@ -168,7 +170,7 @@ def get_pubmed_urls(
 def get_s3_urls(
     bucket: boto3.resources.base.ServiceResource,
     start_date: datetime,
-    end_date: datetime | None = None
+    end_date: datetime | None = None,
 ) -> dict[str, list[str]]:
     """Get S3 urls.
 
@@ -246,7 +248,7 @@ def download_articles(url_list: list[str], output_dir: Path) -> None:
 def download_articles_s3(
     bucket: boto3.resources.base.ServiceResource,
     url_dict: dict[str, list[str]],
-    output_dir: Path
+    output_dir: Path,
 ) -> None:
     """Download articles from AWS S3.
 
@@ -268,4 +270,4 @@ def download_articles_s3(
         for url in url_list:
             output_path = parent_folder / url.split("/")[-1]
             logger.info(f"Downloading {url}")
-            bucket.download_file(url, str(output_path), {'RequestPayer':'requester'})
+            bucket.download_file(url, str(output_path), {"RequestPayer": "requester"})

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -166,7 +166,7 @@ def get_pubmed_urls(
 
 
 def get_s3_urls(
-    bucket,
+    bucket: boto3.resources.base.ServiceResource,
     start_date: datetime,
     end_date: datetime | None = None
 ) -> dict[str, list[str]]:
@@ -244,7 +244,10 @@ def download_articles(url_list: list[str], output_dir: Path) -> None:
 
 
 def download_articles_s3(
-    bucket, url_dict: dict[str, list[str]], output_dir: Path) -> None:
+    bucket: boto3.resources.base.ServiceResource,
+    url_dict: dict[str, list[str]],
+    output_dir: Path
+) -> None:
     """Download articles from AWS S3.
 
     Parameters

--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -22,7 +22,6 @@ import re
 from datetime import datetime, timedelta
 from pathlib import Path
 
-import boto3
 import requests
 from boto3.resources.base import ServiceResource
 

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -160,6 +160,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
             return 0
 
         download_articles_s3(bucket, url_dict, output_dir)
+        return 0
 
     else:
         logger.error(f"The source type {source!r} is not implemented yet")

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -100,6 +100,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
     """
     from bluesearch.database.download import (
         download_articles,
+        download_articles_s3,
         generate_pmc_urls,
         get_pubmed_urls,
         get_s3_urls,
@@ -144,6 +145,9 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
                 print(f"Month: {month}")
                 print(*url_list, sep="\n")
             return 0
+
+        download_articles_s3(source, url_dict, output_dir)
+
 
     else:
         logger.error(f"The source type {source!r} is not implemented yet")

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -100,6 +100,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
     `get_parser` function.
     """
     import boto3
+
     from bluesearch.database.download import (
         download_articles,
         download_s3_articles,

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -102,6 +102,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
         download_articles,
         generate_pmc_urls,
         get_pubmed_urls,
+        get_s3_urls,
     )
 
     if source == "pmc":
@@ -135,6 +136,15 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
         output_dir.mkdir(exist_ok=True, parents=True)
         download_articles(url_list, output_dir)
         return 0
+    elif source in {"biorxiv", "medrxiv"}:
+        url_dict = get_s3_urls(source, from_month) # month -> list of .meca file paths
+
+        if dry_run:
+            for month, url_list in url_dict.items():
+                print(f"Month: {month}")
+                print(*url_list, sep="\n")
+            return 0
+
     else:
         logger.error(f"The source type {source!r} is not implemented yet")
         return 1

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -102,7 +102,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
     import boto3
     from bluesearch.database.download import (
         download_articles,
-        download_articles_s3,
+        download_s3_articles,
         generate_pmc_urls,
         get_pubmed_urls,
         get_s3_urls,
@@ -159,7 +159,8 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
                 print(*url_list, sep="\n")
             return 0
 
-        download_articles_s3(bucket, url_dict, output_dir)
+        logger.info(f"Start downloading {source} papers.")
+        download_s3_articles(bucket, url_dict, output_dir)
         return 0
 
     else:

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -161,7 +161,6 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
 
         download_articles_s3(bucket, url_dict, output_dir)
 
-
     else:
         logger.error(f"The source type {source!r} is not implemented yet")
         return 1

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -9,7 +9,7 @@ import responses
 
 from bluesearch.database.download import (
     download_articles,
-    download_articles_s3,
+    download_s3_articles,
     generate_pmc_urls,
     get_daterange_list,
     get_pubmed_urls,
@@ -153,7 +153,7 @@ def test_download_articles(tmp_path):
     for file in tmp_path.iterdir():
         assert file.name in path_names
 
-def test_download_articles_s3(tmp_path):
+def test_download_s3_articles(tmp_path):
     def fake_download_file(Key, Filename, ExtraArgs):
         Path(Filename).touch()
 
@@ -169,7 +169,7 @@ def test_download_articles_s3(tmp_path):
             ]
     }
 
-    download_articles_s3(fake_bucket, url_dict, tmp_path)
+    download_s3_articles(fake_bucket, url_dict, tmp_path)
 
     assert (tmp_path / "Current_Content" / "November_2018" / "1.meca").exists()
     assert (tmp_path / "Current_Content" / "December_2018" / "2.meca").exists()

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -65,7 +65,6 @@ class TestGetDaterangeList:
             get_daterange_list(datetime.today(), delta="wrong delta")
 
 
-
 @pytest.mark.parametrize(
     ("component", "expected_url_start"),
     [
@@ -108,22 +107,21 @@ def test_get_pubmed_urls(monkeypatch, test_data_path):
     for url in url_list:
         assert url.startswith(expected_url_start)
 
+
 def test_get_s3_urls():
     n_papers_per_month = 20
     S3object = namedtuple("S3object", ["key"])
 
     fake_bucket = Mock()
-    return_value = [
-        S3object("whatever.meca") for _ in range(n_papers_per_month)
-    ] + [S3object("some_folder/")]
+    return_value = [S3object("whatever.meca") for _ in range(n_papers_per_month)] + [
+        S3object("some_folder/")
+    ]
     fake_bucket.objects.filter.return_value = return_value
 
     start_date = datetime(2019, 11, 13)
     end_date = datetime(2020, 2, 22)
 
-
     url_dict = get_s3_urls(fake_bucket, start_date, end_date)
-
 
     expected_keys = {
         "November_2019",
@@ -153,6 +151,7 @@ def test_download_articles(tmp_path):
     for file in tmp_path.iterdir():
         assert file.name in path_names
 
+
 def test_download_s3_articles(tmp_path):
     def fake_download_file(Key, Filename, ExtraArgs):
         Path(Filename).touch()
@@ -166,7 +165,7 @@ def test_download_s3_articles(tmp_path):
         "January_2019": [
             "Current_Content/January_2019/3.meca",
             "Current_Content/January_2019/4.meca",
-            ]
+        ],
     }
 
     download_s3_articles(fake_bucket, url_dict, tmp_path)

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -133,7 +133,7 @@ def test_get_s3_urls():
     assert isinstance(url_dict, dict)
     assert set(url_dict.keys()) == expected_keys
 
-    for month_year, url_list in url_dict.items():
+    for _, url_list in url_dict.items():
         assert len(url_list) == n_papers_per_month
 
 

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -7,21 +7,21 @@ import responses
 from bluesearch.database.download import (
     download_articles,
     generate_pmc_urls,
-    get_days_list,
+    get_daterange_list,
     get_pubmed_urls,
 )
 
 
-def test_get_days_list():
+def test_get_daterange_list():
     start_date = datetime.strptime("2021-11", "%Y-%m")
     end_date = datetime.strptime("2021-12", "%Y-%m")
-    days_list = get_days_list(start_date, end_date)
+    days_list = get_daterange_list(start_date, end_date)
     assert isinstance(days_list, list)
     assert len(days_list) == 31  # 30 days in November + 1 in December
     for day in days_list:
         assert isinstance(day, datetime)
 
-    days_list = get_days_list(start_date)
+    days_list = get_daterange_list(start_date)
     assert isinstance(days_list, list)
     for day in days_list:
         assert isinstance(day, datetime)

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -118,6 +118,7 @@ def test_pubmed_download(capsys, monkeypatch, tmp_path):
     assert fake_get_pubmed_urls.call_count == 1
     assert fake_download_articles.call_count == 0
 
+
 @pytest.mark.parametrize("source", ["biorxiv", "medrxiv"])
 def test_biorxiv_medrxiv_download(source, monkeypatch, tmp_path, capsys):
     def fake_download_s3_articles_func(bucket, url_dict, output_dir):
@@ -125,7 +126,6 @@ def test_biorxiv_medrxiv_download(source, monkeypatch, tmp_path, capsys):
             for url in url_list:
                 output_path = output_dir / url
                 output_path.touch()
-
 
     # Define mocks
     fake_getpass = Mock()

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -117,3 +117,66 @@ def test_pubmed_download(capsys, monkeypatch, tmp_path):
     assert len(captured.out.split("\n")) == 1 + 2 + 1
     assert fake_get_pubmed_urls.call_count == 1
     assert fake_download_articles.call_count == 0
+
+@pytest.mark.parametrize("source", ["biorxiv", "medrxiv"])
+def test_biorxiv_medrxiv_download(source, monkeypatch, tmp_path, capsys):
+    def fake_download_s3_articles_func(bucket, url_dict, output_dir):
+        for url_list in url_dict.values():
+            for url in url_list:
+                output_path = output_dir / url
+                output_path.touch()
+
+
+    # Define mocks
+    fake_getpass = Mock()
+    fake_getpass.getpass.return_value = "somecredentials"
+    fake_datetime = datetime(2021, 11, 1)
+
+    fake_get_s3_urls = Mock(
+        return_value={
+            "November_2018": ["1.meca"],
+            "December_2018": ["2.meca"],
+        }
+    )
+
+    fake_download_s3_articles = Mock(side_effect=fake_download_s3_articles_func)
+
+    # Patch
+    monkeypatch.setattr(
+        "bluesearch.entrypoint.database.download.getpass",
+        fake_getpass,
+    )
+    monkeypatch.setattr(
+        "bluesearch.database.download.get_s3_urls",
+        fake_get_s3_urls,
+    )
+    monkeypatch.setattr(
+        "bluesearch.database.download.download_s3_articles",
+        fake_download_s3_articles,
+    )
+
+    # Run the command (no dry run)
+    download.run(source, fake_datetime, tmp_path, dry_run=False)
+
+    # Asserts
+    fake_get_s3_urls.assert_called_once()
+    fake_download_s3_articles.assert_called_once()
+    assert fake_getpass.getpass.call_count == 2
+
+    assert len(list(tmp_path.iterdir())) == 2
+
+    # Reset mocks
+    fake_get_s3_urls.reset_mock()
+    fake_download_s3_articles.reset_mock()
+    fake_getpass.reset_mock()
+
+    # Run the command dry run
+    download.run(source, fake_datetime, tmp_path, dry_run=True)
+
+    # Asserts
+    fake_get_s3_urls.assert_called_once()
+    fake_download_s3_articles.assert_not_called()
+    assert fake_getpass.getpass.call_count == 2
+
+    stdout = capsys.readouterr().out
+    assert "Month: November_2018\n1.meca\nMonth: December_2018\n2.meca\n" in stdout


### PR DESCRIPTION
Fixes #512 

## Description

Implements the download logic for `biorxiv` and `medrxiv`.

## How to test?
Note that the entrypoints will ask you to enter the credentials!

To run the dry run
```bash
bbs_database download medrxiv -n 2021-10 output_folder
```
To run an actual download
```bash
bbs_database download biorxiv 2021-10 output_folder
```

## Checklist

- [ ] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
