### PR TITLE
Implement `bbs_database download` for arXiv

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,7 @@ Legend
 
 Latest
 ======
+- |Add| code to download :code:`arxiv` papers from a given date.
 - |Add| code to download :code:`PMC` papers from a given date.
 - |Add| entrypoint :code:`bbs_database download`.
 - |Add| run the tox env ``check-apidoc`` in CI

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ catalogue==2.0.4
 cryptography==3.4.7
 defusedxml==0.6.0
 en-core-sci-lg @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.4.0/en_core_sci_lg-0.4.0.tar.gz
-google-api-python-client==2.32.0
+google-cloud-storage==1.43.0
 h5py==3.3.0
 ipython==7.25.0
 ipywidgets==7.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ catalogue==2.0.4
 cryptography==3.4.7
 defusedxml==0.6.0
 en-core-sci-lg @ https://s3-us-west-2.amazonaws.com/ai2-s2-scispacy/releases/v0.4.0/en_core_sci_lg-0.4.0.tar.gz
+google-api-python-client==2.32.0
 h5py==3.3.0
 ipython==7.25.0
 ipywidgets==7.6.3

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ INSTALL_REQUIRES = [
     # Required to encrypt mysql password; >= 3.2 to fix RSA decryption vulnerability
     "cryptography>=3.2",
     "defusedxml",
+    "google-api-python-client",
     "h5py",
     "ipython",
     "ipywidgets",

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ INSTALL_REQUIRES = [
     # Required to encrypt mysql password; >= 3.2 to fix RSA decryption vulnerability
     "cryptography>=3.2",
     "defusedxml",
-    "google-api-python-client",
+    "google-cloud-storage",
     "h5py",
     "ipython",
     "ipywidgets",

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -212,7 +212,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
                 )
                 job_names[future] = blob.name
                 n_blobs += 1
-                n_bytes += blob.size
+                n_bytes += blob.size or 0
                 if n_blobs % 100 == 0:
                     progress_info(n_blobs, n_bytes)
             progress_info(n_blobs, n_bytes)

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -177,7 +177,7 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
             logger.error(
                 "The papers from before April 2007 follow a different format "
                 "and can't be downloaded. Please contact the developers if you "
-                "need them. To process please re-run the command with a "
+                "need them. To proceed please re-run the command with a "
                 "different starting month."
             )
             return 1

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -18,7 +18,9 @@
 import argparse
 import getpass
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
+from itertools import chain
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -163,7 +165,68 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
         logger.info(f"Start downloading {source} papers.")
         download_s3_articles(bucket, url_dict, output_dir)
         return 0
+    elif source == "arxiv":
+        logger.info("Loading libraries")
+        from google.cloud.storage import Client
 
+        from bluesearch.database.download import download_gcs_blob, get_gcs_urls
+
+        client = Client.create_anonymous_client()
+        bucket = client.bucket("arxiv-dataset")
+        if from_month < datetime(2007, 4, 1):
+            logger.error(
+                "The papers from before April 2007 follow a different format "
+                "and can't be downloaded. Please contact the developers if you "
+                "need them. To process please re-run the command with a "
+                "different starting month."
+            )
+            return 1
+
+        logger.info("Collecting download URLs")
+        blobs_by_month = get_gcs_urls(bucket, from_month)
+
+        if dry_run:
+            print("The following items will be downloaded:")
+            for month, month_blobs in blobs_by_month.items():
+                print(f"Month: {month}")
+                for blob in month_blobs:
+                    print(blob.name)
+            return 0
+
+        def progress_info(n_jobs, n_bytes_):
+            logger.info(f"{n_jobs} download jobs submitted ({n_bytes_:,d} bytes)")
+
+        job_names = {}
+        n_blobs = 0
+        n_bytes = 0
+        # The max_workers parameter already has a reasonable default if
+        # not specified. See python docs for ThreadPoolExecutor.
+        with ThreadPoolExecutor() as executor:
+            logger.info("Submitting download jobs to workers")
+            for blob in chain(*blobs_by_month.values()):
+                future = executor.submit(
+                    download_gcs_blob,
+                    blob,
+                    output_dir,
+                    flatten=True,
+                )
+                job_names[future] = blob.name
+                n_blobs += 1
+                n_bytes += blob.size
+                if n_blobs % 100 == 0:
+                    progress_info(n_blobs, n_bytes)
+            progress_info(n_blobs, n_bytes)
+            logger.info("Waiting for the downloads to finish (may take a while)")
+            for future in as_completed(job_names):
+                job_name = job_names[future]
+                exc = future.exception()
+                if exc:
+                    logger.error("The job %s failed, reason: %s", job_name, exc)
+                else:
+                    logger.debug("The job %s succeeded.", job_name)
+            logger.info("Finished downloading")
     else:
         logger.error(f"The source type {source!r} is not implemented yet")
         return 1
+
+    return 0

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -209,9 +209,15 @@ def test_get_gcs_urls():
 
     assert fake_client.list_blobs.call_count == 3
     assert set(blobs_by_month) == {"2110", "2111", "2112"}
-    assert blobs_by_month["2110"] == fake_blobs_by_prefix["arxiv/arxiv/pdf/2110"]
-    assert blobs_by_month["2111"] == fake_blobs_by_prefix["arxiv/arxiv/pdf/2111"][-1:]
-    assert blobs_by_month["2112"] == fake_blobs_by_prefix["arxiv/arxiv/pdf/2112"][:-1]
+    assert set(blobs_by_month["2110"]) == set(
+        fake_blobs_by_prefix["arxiv/arxiv/pdf/2110"]
+    )
+    assert set(blobs_by_month["2111"]) == set(
+        fake_blobs_by_prefix["arxiv/arxiv/pdf/2111"][-1:]
+    )
+    assert set(blobs_by_month["2112"]) == set(
+        fake_blobs_by_prefix["arxiv/arxiv/pdf/2112"][:-1]
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -200,7 +200,9 @@ def test_get_gcs_urls():
         ],
     }
 
-    fake_client.list_blobs.side_effect = lambda bucket, prefix: fake_blobs_by_prefix[prefix]
+    fake_client.list_blobs.side_effect = lambda bucket, prefix: fake_blobs_by_prefix[
+        prefix
+    ]
     start_date = datetime(2021, 10, 1)
     end_date = datetime(2021, 12, 1)
     blobs_by_month = get_gcs_urls(fake_bucket, start_date, end_date)

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -200,11 +200,12 @@ def test_get_gcs_urls():
         ],
     }
 
-    fake_client.list_blobs = lambda bucket, prefix: fake_blobs_by_prefix[prefix]
+    fake_client.list_blobs.side_effect = lambda bucket, prefix: fake_blobs_by_prefix[prefix]
     start_date = datetime(2021, 10, 1)
     end_date = datetime(2021, 12, 1)
     blobs_by_month = get_gcs_urls(fake_bucket, start_date, end_date)
 
+    assert fake_client.list_blobs.call_count == 3
     assert set(blobs_by_month) == {"2110", "2111", "2112"}
     assert blobs_by_month["2110"] == fake_blobs_by_prefix["arxiv/arxiv/pdf/2110"]
     assert blobs_by_month["2111"] == fake_blobs_by_prefix["arxiv/arxiv/pdf/2111"][-1:]

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -230,7 +230,7 @@ class TestArxivDownload:
         assert "different format" in caplog.text
 
     def test_dry_run(self, capsys, tmp_path, mocked):
-        # The dry run should print all months and blobs to stdouts
+        # The dry run should print all months and blobs to stdout
         download.run("arxiv", datetime(2021, 12, 1), tmp_path, dry_run=True)
         stdout, stderr = capsys.readouterr()
         for month, blobs in mocked.get_gcs_urls().items():


### PR DESCRIPTION
Fixes #513 

## Description
This implements the `bbs_database download arxiv` command.

There are several open question to discuss:
- The downloads contain all published versions of a given article (`XXXv1.pdf`, `XXXv2.pdf`, ...)
  - what do we want to do with them?
  - when do we want to do it?
- Is it possible that a new article version is published later and added to the same folder? How do we check that? (if we want to do that at all)
- The current implementation shows an error if the starting date is earlier than April 2007, this is when the new arxiv IDs were introduced. It's easy to implement downloads from before April 2007, but:
  - They are already pre-sorted into categories, e.g. `q-bio`, while the new ones aren't
  - So do we only want to download `q-bio` in that case?
  - If yes, do we mix the `q-bio` download from before April 2007 with the more recent ones that come from across all categories?
  - If we do mix, will this affect the subsequent topic filtering?
- At this stage no metadata processing and filtering is done at all. As a consequence PDFs from all categories are downloaded
  - This is pretty wasteful both server and client side
  - Can we do better or are we happy with the current approach?
 
## How to test?
Try the dry run:
```sh
bbs_database download -n arxiv 2021-12 out > to-download.txt
less to-download.txt
```

Try the real download (you'll probably want to ctrl+C at some point, it's a lot):
```sh
bbs_database download -v arxiv 2021-12 out
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
