### PR TITLE
Implement `topic-extract --source=pmc`

### DIFF
--- a/docs/source/api/bluesearch.entrypoint.database.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.rst
@@ -14,6 +14,7 @@ Submodules
    bluesearch.entrypoint.database.parent
    bluesearch.entrypoint.database.parse
    bluesearch.entrypoint.database.schemas
+   bluesearch.entrypoint.database.topic_extract
 
 Module contents
 ---------------

--- a/docs/source/api/bluesearch.entrypoint.database.topic_extract.rst
+++ b/docs/source/api/bluesearch.entrypoint.database.topic_extract.rst
@@ -1,0 +1,7 @@
+bluesearch.entrypoint.database.topic\_extract module
+====================================================
+
+.. automodule:: bluesearch.entrypoint.database.topic_extract
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -89,27 +89,8 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
 
     content = ElementTree.fromstring(text)
 
-    # When the number of results is equal to 1, we take it.
-    nlm_catalog_records = content.findall("./NCBICatalogRecord/NLMCatalogRecord")
-    if len(nlm_catalog_records) == 1:
-        mesh_headings = nlm_catalog_records[0].findall("./MeshHeadingList/MeshHeading")
-        return _parse_mesh_from_nlm_catalog(mesh_headings)
-
-    # Otherwise we look for a perfect match of the title
-    for child in nlm_catalog_records:
-        title_main = child.find("./TitleMain/Title")
-        if title_main is None:
-            continue
-        nlm_ta = nlm_ta.lower().strip()
-        if title_main.text.lower().strip() in [
-            nlm_ta,
-            nlm_ta + ".",
-            nlm_ta + " .",
-        ]:
-            mesh_headings = child.findall("./MeshHeadingList/MeshHeading")
-            return _parse_mesh_from_nlm_catalog(mesh_headings)
-
-    return None
+    mesh_headings = content.findall("./NCBICatalogRecord/NLMCatalogRecord/MeshHeadingList/MeshHeading")
+    return _parse_mesh_from_nlm_catalog(mesh_headings)
 
 
 # Article Topic

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 # Journal Topic
 @lru_cache(maxsize=None)
 def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
-    """Retrieve Medical Subject Heading from Journal's NLM Title.
+    """Retrieve Medical Subject Heading from Journal's NLM Title Abbreviation.
 
     Parameters
     ----------

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import html
 import pathlib
-from typing import Iterable
+from typing import Iterable, List, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 import requests
@@ -261,3 +261,14 @@ def _parse_mesh_from_pubmed(mesh_headings: Iterable[Element]) -> list[dict]:
             meshs.append({"descriptor": descriptor_name, "qualifiers": qualifiers_name})
 
     return meshs
+
+
+# PMC source
+def get_topics_for_pmc_article(
+    pmc_path: pathlib.Path | str,
+) -> Tuple[List[str], List[str]]:
+    """Extract journal and article topics of a PMC article."""
+    journal_topics = []
+    article_topics = []
+
+    return journal_topics, article_topics

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Utils for journal/articles topics."""
 from __future__ import annotations
+from functools import lru_cache
 
 import html
 import pathlib
@@ -29,6 +30,7 @@ from bluesearch.database.article import JATSXMLParser
 
 
 # Journal Topic
+@lru_cache(maxsize=None)
 def request_mesh_from_journal_title(journal_title: str) -> list[dict] | None:
     """Retrieve Medical Subject Heading from Journal's NLM Title.
 

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -266,7 +266,6 @@ def get_topics_for_pmc_article(
     journal_topics = None
 
     # Determine journal title
-    logger.info(f"Reading file {pmc_path}")
     parser = JATSXMLParser(pmc_path)
     nlm_ta = parser.content.find(
         "./front/journal-meta/journal-id[@journal-id-type='nlm-ta']"
@@ -275,7 +274,7 @@ def get_topics_for_pmc_article(
         return journal_topics
 
     nlm_ta = nlm_ta.text
-    logger.info(f"Journal Title: {nlm_ta}")
+    logger.info(f"Journal Title Abbreviation: {nlm_ta}")
     journal_meshes = request_mesh_from_nlm_ta(nlm_ta)
     logger.info(journal_meshes)
 

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -262,7 +262,18 @@ def _parse_mesh_from_pubmed(mesh_headings: Iterable[Element]) -> list[dict]:
 def get_topics_for_pmc_article(
     pmc_path: pathlib.Path | str,
 ) -> List[str] | None:
-    """Extract journal topics of a PMC article."""
+    """Extract journal topics of a PMC article.
+
+    Parameters
+    ----------
+    pmc_path
+        Path to the PMC article to consider
+
+    Returns
+    -------
+    journal_topics : Optional[list[str]]
+        Journal topics for the given article.
+    """
     # Determine journal title
     parser = JATSXMLParser(pmc_path)
     nlm_ta = parser.content.find(

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -86,7 +86,7 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
-    if text == "":
+    if text == "<pre></pre>":
         logger.error(f"Empty body for query\n{url}")
         return None
 

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -80,7 +80,7 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     if not text.startswith(header) or not text.endswith(footer):
         logger.error(f"Unexpected response for query\n{url}")
         return None
-    text = html.unescape(text[len(header) - 5:]).strip()
+    text = html.unescape(text[len(header) - 5 :]).strip()
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
@@ -89,7 +89,9 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
 
     content = ElementTree.fromstring(text)
 
-    mesh_headings = content.findall("./NCBICatalogRecord/NLMCatalogRecord/MeshHeadingList/MeshHeading")
+    mesh_headings = content.findall(
+        "./NCBICatalogRecord/NLMCatalogRecord/MeshHeadingList/MeshHeading"
+    )
     return _parse_mesh_from_nlm_catalog(mesh_headings)
 
 

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -271,14 +271,14 @@ def get_topics_for_pmc_article(
         "./front/journal-meta/journal-id[@journal-id-type='nlm-ta']"
     )
     if nlm_ta is None:
+        logger.error(f"No NLM Title Abbreviation found for {pmc_path}")
         return journal_topics
 
     nlm_ta = nlm_ta.text
     logger.info(f"Journal Title Abbreviation: {nlm_ta}")
     journal_meshes = request_mesh_from_nlm_ta(nlm_ta)
-    logger.info(journal_meshes)
 
-    if journal_meshes:
+    if journal_meshes is not None:
         journal_topics = []
         for mesh in journal_meshes:
             for descriptor in mesh["descriptor"]:

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -65,7 +65,7 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     base_url = "https://www.ncbi.nlm.nih.gov/nlmcatalog"
     params = {"term": f'"{nlm_ta}"[ta]', "report": "xml", "format": "text"}
 
-    response = requests.get(url, params=params)
+    response = requests.get(base_url, params=params)
     response.raise_for_status()
 
     # The way NCBI responds to these queries is weird: it takes the XML file,
@@ -82,14 +82,14 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     )
     footer = "</pre>"
     if not text.startswith(header) or not text.endswith(footer):
-        logger.error(f"Unexpected response for query\n{url}")
+        logger.error(f"Unexpected response for parameters \n{params}")
         return None
     text = html.unescape(text[len(header) - 5 :]).strip()
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
     if text == "<pre></pre>":
-        logger.error(f"Empty body for query\n{url}")
+        logger.error(f"Empty body for parameters \n{params}")
         return None
 
     content = ElementTree.fromstring(text)

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -52,6 +52,8 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     https://www.ncbi.nlm.nih.gov/books/NBK3799/#catalog.Title_Abbreviation_ta
     """
     if "&" in nlm_ta:
+        logger.error("Ampersands not allowed in the NLM title abbreviation. "
+                     f"Try unescaping HTML characters first. Got:\n{nlm_ta}")
         return None
 
     # The "format=text" parameter only matters when no result was found. With
@@ -80,15 +82,15 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     if not text.startswith(header) or not text.endswith(footer):
         logger.error(f"Unexpected response for query\n{url}")
         return None
-    text = html.unescape(text[len(header) - 5 :]).strip()
+    text = html.unescape(text[len(header) - 5:]).strip()
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
     if text == "":
+        logger.error(f"Empty body for query\n{url}")
         return None
 
     content = ElementTree.fromstring(text)
-
     mesh_headings = content.findall(
         "./NCBICatalogRecord/NLMCatalogRecord/MeshHeadingList/MeshHeading"
     )

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -16,13 +16,13 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Utils for journal/articles topics."""
 from __future__ import annotations
-from functools import lru_cache
 
 import html
 import logging
 import pathlib
-from typing import Iterable, List, Tuple
-from xml.etree.ElementTree import Element, ParseError  # nosec
+from functools import lru_cache
+from typing import Iterable, List
+from xml.etree.ElementTree import Element  # nosec
 
 import requests
 from defusedxml import ElementTree
@@ -58,7 +58,7 @@ def request_mesh_from_journal_title(journal_title: str) -> list[dict] | None:
     # this parameter the returned text will be an empty string. See the
     # corresponding check further below. Without this parameter the output is
     # an HTML page, which is impossible to parse.
-    base_url = 'https://www.ncbi.nlm.nih.gov/nlmcatalog'
+    base_url = "https://www.ncbi.nlm.nih.gov/nlmcatalog"
     url = f'{base_url}?term="{journal_title}"[jo]&report=xml&format=text'
 
     response = requests.get(url)
@@ -80,7 +80,7 @@ def request_mesh_from_journal_title(journal_title: str) -> list[dict] | None:
     if not text.startswith(header) or not text.endswith(footer):
         logger.error(f"Unexpected response for query\n{url}")
         return None
-    text = html.unescape(text[len(header)-5:]).strip()
+    text = html.unescape(text[len(header) - 5 :]).strip()
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
@@ -101,7 +101,11 @@ def request_mesh_from_journal_title(journal_title: str) -> list[dict] | None:
         if title_main is None:
             continue
         journal_title = journal_title.lower().strip()
-        if title_main.text.lower().strip() in [journal_title, journal_title + ".", journal_title + " ."]:
+        if title_main.text.lower().strip() in [
+            journal_title,
+            journal_title + ".",
+            journal_title + " .",
+        ]:
             mesh_headings = child.findall("./MeshHeadingList/MeshHeading")
             return _parse_mesh_from_nlm_catalog(mesh_headings)
 
@@ -277,7 +281,9 @@ def get_topics_for_pmc_article(
     # Determine journal title
     logger.info(f"Reading file {pmc_path}")
     parser = JATSXMLParser(pmc_path)
-    journal_title = parser.content.find("./front/journal-meta/journal-title-group/journal-title")
+    journal_title = parser.content.find(
+        "./front/journal-meta/journal-title-group/journal-title"
+    )
     if journal_title is None:
         return journal_topics
 
@@ -290,6 +296,7 @@ def get_topics_for_pmc_article(
     logger.info(f"Request done for {pmc_path}")
 
     if journal_meshes:
+        journal_topics = []
         for mesh in journal_meshes:
             for descriptor in mesh["descriptor"]:
                 journal_topics.append(descriptor["name"])

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -270,34 +270,25 @@ def _parse_mesh_from_pubmed(mesh_headings: Iterable[Element]) -> list[dict]:
 # PMC source
 def get_topics_for_pmc_article(
     pmc_path: pathlib.Path | str,
-) -> Tuple[List[str], List[str]]:
-    """Extract journal and article topics of a PMC article."""
+) -> List[str]:
+    """Extract journal topics of a PMC article."""
     journal_topics = []
-    article_topics = []
-
-    # Determine pubmed id
-    parser = JATSXMLParser(pmc_path)
-    pubmed_id = parser.pubmed_id
-    if pubmed_id is not None:
-        article_meshes = request_mesh_from_pubmed_id([pubmed_id, ])
-        if pubmed_id in article_meshes:
-            article_meshes = article_meshes[pubmed_id]
-            for mesh in article_meshes:
-                for descriptor in mesh["descriptor"]:
-                    article_topics.append(descriptor["name"])
 
     # Determine journal title
+    parser = JATSXMLParser(pmc_path)
     journal_title = parser.content.find("./front/journal-meta/journal-title-group/journal-title")
-    if journal_title is not None:
-        journal_title = journal_title.text
-        try:
-            journal_meshes = request_mesh_from_journal_title(html.escape(journal_title))
-        except ParseError:
-            return journal_topics, article_topics
+    if journal_title is None:
+        return journal_topics
 
-        if journal_meshes:
-            for mesh in journal_meshes:
-                for descriptor in mesh["descriptor"]:
-                    journal_topics.append(descriptor["name"])
+    journal_title = journal_title.text
+    try:
+        journal_meshes = request_mesh_from_journal_title(html.escape(journal_title))
+    except ParseError:
+        return journal_topics
 
-    return journal_topics, article_topics
+    if journal_meshes:
+        for mesh in journal_meshes:
+            for descriptor in mesh["descriptor"]:
+                journal_topics.append(descriptor["name"])
+
+    return journal_topics

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -263,8 +263,6 @@ def get_topics_for_pmc_article(
     pmc_path: pathlib.Path | str,
 ) -> List[str] | None:
     """Extract journal topics of a PMC article."""
-    journal_topics = None
-
     # Determine journal title
     parser = JATSXMLParser(pmc_path)
     nlm_ta = parser.content.find(
@@ -272,16 +270,17 @@ def get_topics_for_pmc_article(
     )
     if nlm_ta is None:
         logger.error(f"No NLM Title Abbreviation found for {pmc_path}")
-        return journal_topics
+        return None
 
     nlm_ta = nlm_ta.text
     logger.info(f"Journal Title Abbreviation: {nlm_ta}")
     journal_meshes = request_mesh_from_nlm_ta(nlm_ta)
+    if journal_meshes is None:
+        return None
 
-    if journal_meshes is not None:
-        journal_topics = []
-        for mesh in journal_meshes:
-            for descriptor in mesh["descriptor"]:
-                journal_topics.append(descriptor["name"])
+    journal_topics = []
+    for mesh in journal_meshes:
+        for descriptor in mesh["descriptor"]:
+            journal_topics.append(descriptor["name"])
 
     return journal_topics

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -63,9 +63,9 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     # corresponding check further below. Without this parameter the output is
     # an HTML page, which is impossible to parse.
     base_url = "https://www.ncbi.nlm.nih.gov/nlmcatalog"
-    url = f'{base_url}?term="{nlm_ta}"[ta]&report=xml&format=text'
+    params = {"term": f'"{nlm_ta}"[ta]', "report": "xml", "format": "text"}
 
-    response = requests.get(url)
+    response = requests.get(url, params=params)
     response.raise_for_status()
 
     # The way NCBI responds to these queries is weird: it takes the XML file,

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -52,8 +52,10 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     https://www.ncbi.nlm.nih.gov/books/NBK3799/#catalog.Title_Abbreviation_ta
     """
     if "&" in nlm_ta:
-        logger.error("Ampersands not allowed in the NLM title abbreviation. "
-                     f"Try unescaping HTML characters first. Got:\n{nlm_ta}")
+        logger.error(
+            "Ampersands not allowed in the NLM title abbreviation. "
+            f"Try unescaping HTML characters first. Got:\n{nlm_ta}"
+        )
         return None
 
     # The "format=text" parameter only matters when no result was found. With
@@ -82,7 +84,7 @@ def request_mesh_from_nlm_ta(nlm_ta: str) -> list[dict] | None:
     if not text.startswith(header) or not text.endswith(footer):
         logger.error(f"Unexpected response for query\n{url}")
         return None
-    text = html.unescape(text[len(header) - 5:]).strip()
+    text = html.unescape(text[len(header) - 5 :]).strip()
 
     # Empty text means topic abbreviation was not found. See comment about the
     # parameter "format=text" above.
@@ -276,8 +278,6 @@ def get_topics_for_pmc_article(
     logger.info(f"Journal Title: {nlm_ta}")
     journal_meshes = request_mesh_from_nlm_ta(nlm_ta)
     logger.info(journal_meshes)
-
-    logger.info(f"Request done for {pmc_path}")
 
     if journal_meshes:
         journal_topics = []

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -5,7 +5,7 @@ import sys
 from collections import namedtuple
 from typing import Optional, Sequence
 
-from bluesearch.entrypoint.database import add, convert_pdf, download, init, parse
+from bluesearch.entrypoint.database import add, convert_pdf, download, init, parse, topic_extract
 
 Cmd = namedtuple("Cmd", ["help", "init_parser", "run"])
 
@@ -60,6 +60,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             help="Parse raw files.",
             init_parser=parse.init_parser,
             run=parse.run,
+        ),
+        "topic-extract": Cmd(
+            help="Extract topic of article(s).",
+            init_parser=topic_extract.init_parser,
+            run=topic_extract.run,
         ),
     }
 

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -5,7 +5,14 @@ import sys
 from collections import namedtuple
 from typing import Optional, Sequence
 
-from bluesearch.entrypoint.database import add, convert_pdf, download, init, parse, topic_extract
+from bluesearch.entrypoint.database import (
+    add,
+    convert_pdf,
+    download,
+    init,
+    parse,
+    topic_extract,
+)
 
 Cmd = namedtuple("Cmd", ["help", "init_parser", "run"])
 

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -212,8 +212,10 @@ def run(
     try:
         inputs = filter_files(input_path, recursive, match_filename)
     except ValueError:
-        logger.error("Argument 'input_path' should be a path "
-                     "to an existing file or directory!")
+        logger.error(
+            "Argument 'input_path' should be a path "
+            "to an existing file or directory!"
+        )
         return 1
 
     if dry_run:

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -18,10 +18,9 @@
 import argparse
 import json
 import logging
-import re
 import warnings
 from pathlib import Path
-from typing import Iterable, Iterator, Optional
+from typing import Iterator, Optional
 
 from defusedxml import ElementTree
 
@@ -141,58 +140,6 @@ def iter_parsers(input_type: str, input_path: Path) -> Iterator[ArticleParser]:
         raise ValueError(f"Unsupported input type '{input_type}'!")
 
 
-def filter_files(
-    input_path: Path,
-    recursive: bool,
-    match_filename: Optional[str] = None,
-) -> Iterable[Path]:
-    """Create a list of files from input_file.
-
-    Parameters
-    ----------
-    input_path
-        File or directory to consider.
-    recursive
-        If True, directories and all subdirectories are considered in a recursive way.
-    match_filename
-        Only filename matching match_filename are kept.
-
-    Returns
-    -------
-    inputs : Iterable[pathlib.Path]
-        List of kept files.
-
-    Raises
-    ------
-    ValueError
-        If the input_path does not exists.
-    """
-    if input_path.is_file():
-        return [input_path]
-
-    elif input_path.is_dir():
-        if recursive:
-            pattern = "**/*"
-        else:
-            pattern = "*"
-        files = (x for x in input_path.glob(pattern) if x.is_file())
-
-        if match_filename is None:
-            selected = files
-        elif match_filename == "":
-            raise ValueError("Value for argument 'match-filename' should not be empty!")
-        else:
-            regex = re.compile(match_filename)
-            selected = (x for x in files if regex.fullmatch(x.name))
-
-        return sorted(selected)
-
-    else:
-        raise ValueError(
-            "Argument 'input_path' should be a path to an existing file or directory!"
-        )
-
-
 def run(
     *,
     input_type: str,
@@ -207,8 +154,10 @@ def run(
     Parameter description and potential defaults are documented inside of the
     `get_parser` function.
     """
+    from bluesearch.utils import find_files
+
     try:
-        inputs = filter_files(input_path, recursive, match_filename)
+        inputs = find_files(input_path, recursive, match_filename)
     except ValueError:
         logger.error(
             "Argument 'input_path' should be a path "

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -167,8 +167,6 @@ def filter_files(
     ValueError
         If the input_path does not exists.
     """
-    inputs: Iterable[Path]
-
     if input_path.is_file():
         return [input_path]
 

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -130,34 +130,14 @@ def run(
     """
     import bluesearch
     from bluesearch.database.topic import get_topics_for_pmc_article
+    from bluesearch.entrypoint.database.parse import filter_files
     from bluesearch.utils import JSONL
 
-    inputs: Iterable[Path]
-
-    if input_path.is_file():
-        inputs = [input_path]
-
-    elif input_path.is_dir():
-        if recursive:
-            pattern = "**/*"
-        else:
-            pattern = "*"
-        files = (x for x in input_path.glob(pattern) if x.is_file())
-
-        if match_filename is None:
-            selected = files
-        elif match_filename == "":
-            raise ValueError("Value for argument 'match-filename' should not be empty!")
-        else:
-            regex = re.compile(match_filename)
-            selected = (x for x in files if regex.fullmatch(x.name))
-
-        inputs = sorted(selected)
-
-    else:
-        logger.error(
-            "Argument 'input_path' should be a path to an existing file or directory!"
-        )
+    try:
+        inputs = filter_files(input_path, recursive, match_filename)
+    except ValueError:
+        logger.error("Argument 'input_path' should be a path "
+                     "to an existing file or directory!")
         return 1
 
     if dry_run:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -22,7 +22,7 @@ import datetime
 import logging
 import re
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +97,8 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         action="store_true",
         help="""
         If output_file exists and overwrite is true, the output file is overwrote.
+        Otherwise, the topic extraction results are going
+        to be appended to the `output_file`.
         """,
     )
     parser.add_argument(
@@ -116,7 +118,7 @@ def run(
     input_source: str,
     input_path: Path,
     output_file: Path,
-    match_filename: str,
+    match_filename: Optional[str],
     recursive: bool,
     overwrite: bool,
     dry_run: bool,
@@ -153,9 +155,10 @@ def run(
         inputs = sorted(selected)
 
     else:
-        raise ValueError(
+        logger.error(
             "Argument 'input_path' should be a path to an existing file or directory!"
         )
+        return 1
 
     if dry_run:
         # Inputs are already sorted.
@@ -183,8 +186,10 @@ def run(
                     },
                 }
             )
+    else:
+        logger.error(f"The source type {input_source!r} is not implemented yet")
+        return 1
 
-    mode = "w" if overwrite else "a"
-    JSONL.dump_jsonl(all_results, output_file, mode)
+    JSONL.dump_jsonl(all_results, output_file, overwrite)
 
     return 0

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -154,15 +154,12 @@ def run(
 
     if input_source == "pmc":
         for path in inputs:
-            journal_topics, article_topics = get_topics_for_pmc_article(path)
+            journal_topics = get_topics_for_pmc_article(path)
             all_results.append(
                 {
                     "source": "pmc",
                     "path": path,
                     "topics": {
-                        "article": {
-                            "MeSH": article_topics,
-                        },
                         "journal": {
                             "MeSH": journal_topics,
                         },
@@ -174,7 +171,7 @@ def run(
                 }
             )
 
-    with open(output_file, "wb") as f:
+    with open(output_file, "w") as f:
         json.dump(all_results, f)
 
     return 0

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -15,12 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Extract topic of articles."""
+from __future__ import annotations
+
 import argparse
 import datetime
 import logging
 import re
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 
 logger = logging.getLogger(__name__)
 
@@ -160,7 +162,7 @@ def run(
         print(*inputs, sep="\n")
         return 0
 
-    all_results = []
+    all_results: list[dict[str, Any]] = []
 
     if input_source == "pmc":
         for path in inputs:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 import argparse
 import datetime
 import logging
-import re
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -136,8 +135,10 @@ def run(
     try:
         inputs = filter_files(input_path, recursive, match_filename)
     except ValueError:
-        logger.error("Argument 'input_path' should be a path "
-                     "to an existing file or directory!")
+        logger.error(
+            "Argument 'input_path' should be a path "
+            "to an existing file or directory!"
+        )
         return 1
 
     if dry_run:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -69,7 +69,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "output_file",
         type=Path,
         help="""
-        Path to the file where the results will be saved.
+        Path to the file where the topic information will be written.
         If it does not exist yet, the file is created.
         """,
     )

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -163,7 +163,7 @@ def run(
                     },
                     "metadata": {
                         "created-date": str(datetime.datetime.now()),
-                        "bbs-version": str(bluesearch.version.__version__),
+                        "bbs-version": bluesearch.version.__version__,
                     },
                 }
             )

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -129,11 +129,10 @@ def run(
     """
     import bluesearch
     from bluesearch.database.topic import get_topics_for_pmc_article
-    from bluesearch.entrypoint.database.parse import filter_files
-    from bluesearch.utils import JSONL
+    from bluesearch.utils import JSONL, find_files
 
     try:
-        inputs = filter_files(input_path, recursive, match_filename)
+        inputs = find_files(input_path, recursive, match_filename)
     except ValueError:
         logger.error(
             "Argument 'input_path' should be a path "

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -162,7 +162,9 @@ def run(
                         },
                     },
                     "metadata": {
-                        "created-date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                        "created-date": datetime.datetime.now().strftime(
+                            "%Y-%m-%d %H:%M:%S"
+                        ),
                         "bbs-version": bluesearch.version.__version__,
                     },
                 }

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -162,7 +162,7 @@ def run(
                         },
                     },
                     "metadata": {
-                        "created-date": str(datetime.datetime.now()),
+                        "created-date": datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                         "bbs-version": bluesearch.version.__version__,
                     },
                 }

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -1,0 +1,105 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Extract topic of articles."""
+import argparse
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Initialise the argument parser for the add subcommand.
+
+    Parameters
+    ----------
+    parser
+        The argument parser to initialise.
+
+    Returns
+    -------
+    argparse.ArgumentParser
+        The initialised argument parser. The same object as the `parser`
+        argument.
+    """
+    parser.description = "Extract topic of articles."
+
+    parser.add_argument(
+        "input_source",
+        type=str,
+        choices=(
+            "arxiv",
+            "biorxiv",
+            "medrxiv",
+            "pmc",
+            "pubmed",
+        ),
+        help="""
+        Format of the input.
+        If extracting topic of several articles, all articles must have the same format.
+        """,
+    )
+    parser.add_argument(
+        "input_path",
+        type=Path,
+        help="""
+        Path to a file or directory. If a directory, topic will be extracted for
+        all articles inside the directory.
+        """,
+    )
+    parser.add_argument(
+        "output_file",
+        type=Path,
+        help="""
+        Path to the file where the results will be saved.
+        If it does not exist yet, the file is created.
+        """,
+    )
+    parser.add_argument(
+        "-R",
+        "--recursive",
+        action="store_true",
+        help="""
+        Find articles recursively.
+        """,
+    )
+    parser.add_argument(
+        "-o",
+        "--overwrite",
+        action="store_true",
+        help="""
+        If output_file exists and overwrite is true, the output file is overwrote.
+        """,
+    )
+    return parser
+
+
+def run(
+        *,
+        input_source: str,
+        input_path: Path,
+        output_file: Path,
+        recursive: bool,
+        overwrite: bool,
+) -> int:
+    """Extract topic of articles.
+
+    Parameter description and potential defaults are documented inside of the
+    `get_parser` function.
+    """
+
+    return 0

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -95,7 +95,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         "--overwrite",
         action="store_true",
         help="""
-        If output_file exists and overwrite is true, the output file is overwrote.
+        If output_file exists and overwrite is true, the output file is overwritten.
         Otherwise, the topic extraction results are going
         to be appended to the `output_file`.
         """,

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -43,7 +43,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.description = "Extract topic of articles."
 
     parser.add_argument(
-        "input_source",
+        "source",
         type=str,
         choices=(
             "arxiv",
@@ -114,7 +114,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
 def run(
     *,
-    input_source: str,
+    source: str,
     input_path: Path,
     output_file: Path,
     match_filename: Optional[str],
@@ -148,7 +148,7 @@ def run(
 
     all_results: list[dict[str, Any]] = []
 
-    if input_source == "pmc":
+    if source == "pmc":
         for path in inputs:
             logger.info(f"Processing {path}")
             journal_topics = get_topics_for_pmc_article(path)
@@ -168,7 +168,7 @@ def run(
                 }
             )
     else:
-        logger.error(f"The source type {input_source!r} is not implemented yet")
+        logger.error(f"The source type {source!r} is not implemented yet")
         return 1
 
     JSONL.dump_jsonl(all_results, output_file, overwrite)

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -155,7 +155,7 @@ def run(
             all_results.append(
                 {
                     "source": "pmc",
-                    "path": str(path),
+                    "path": str(path.resolve()),
                     "topics": {
                         "journal": {
                             "MeSH": journal_topics,

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -17,8 +17,10 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
 import json
 import pathlib
+import re
 import time
 import warnings
 from typing import Any, Dict, List, Set, Union
@@ -26,6 +28,58 @@ from typing import Any, Dict, List, Set, Union
 import h5py
 import numpy as np
 import spacy
+
+
+def find_files(
+    input_path: pathlib.Path,
+    recursive: bool,
+    match_filename: str | None = None,
+) -> list[pathlib.Path]:
+    """Find files inside of `input_path`.
+
+    Parameters
+    ----------
+    input_path
+        File or directory to consider.
+    recursive
+        If True, directories and all subdirectories are considered in a recursive way.
+    match_filename
+        Only filename matching match_filename are kept.
+
+    Returns
+    -------
+    inputs : list[pathlib.Path]
+        List of kept files.
+
+    Raises
+    ------
+    ValueError
+        If the input_path does not exists.
+    """
+    if input_path.is_file():
+        return [input_path]
+
+    elif input_path.is_dir():
+        if recursive:
+            pattern = "**/*"
+        else:
+            pattern = "*"
+        files = (x for x in input_path.glob(pattern) if x.is_file())
+
+        if match_filename is None:
+            selected = files
+        elif match_filename == "":
+            raise ValueError("Value for argument 'match-filename' should not be empty!")
+        else:
+            regex = re.compile(match_filename)
+            selected = (x for x in files if regex.fullmatch(x.name))
+
+        return sorted(selected)
+
+    else:
+        raise ValueError(
+            "Argument 'input_path' should be a path to an existing file or directory!"
+        )
 
 
 class Timer:

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -441,7 +441,9 @@ class JSONL:
     """Collection of utility static functions handling `jsonl` files."""
 
     @staticmethod
-    def dump_jsonl(data: List[Dict[str, str]], path: pathlib.Path, mode: str = "w"):
+    def dump_jsonl(
+        data: List[Dict[str, str]], path: pathlib.Path, overwrite: bool = True
+    ):
         """Save a list of dictionaries to a jsonl.
 
         Parameters
@@ -450,12 +452,13 @@ class JSONL:
             List of dictionaries (json files).
         path : pathlib.Path
             File where to save it.
-        mode : {"w", "a"}
-            Mode of writing
+        overwrite : bool
+            If yes, the file is overwritten. Otherwise, the file is appended.
         """
+        mode = "w" if overwrite else "a"
         with path.open(mode) as f:
             for x in data:
-                line = json.dumps(x, indent=True, sort_keys=True)
+                line = json.dumps(x, sort_keys=True)
                 f.write(line + "\n")
 
     @staticmethod

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -21,7 +21,7 @@ import json
 import pathlib
 import time
 import warnings
-from typing import Any, Dict, Set, Union
+from typing import Any, Dict, List, Set, Union
 
 import h5py
 import numpy as np
@@ -441,7 +441,11 @@ class JSONL:
     """Collection of utility static functions handling `jsonl` files."""
 
     @staticmethod
-    def dump_jsonl(data, path):
+    def dump_jsonl(
+            data: List[Dict[str, str]],
+            path: pathlib.Path,
+            mode: str = "w"
+    ):
         """Save a list of dictionaries to a jsonl.
 
         Parameters
@@ -450,10 +454,12 @@ class JSONL:
             List of dictionaries (json files).
         path : pathlib.Path
             File where to save it.
+        mode : {"w", "a"}
+            Mode of writing
         """
-        with path.open("w") as f:
+        with path.open(mode) as f:
             for x in data:
-                line = json.dumps(x)
+                line = json.dumps(x, indent=True, sort_keys=True)
                 f.write(line + "\n")
 
     @staticmethod

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -18,6 +18,7 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 from __future__ import annotations
+
 import json
 import pathlib
 import re

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -441,11 +441,7 @@ class JSONL:
     """Collection of utility static functions handling `jsonl` files."""
 
     @staticmethod
-    def dump_jsonl(
-            data: List[Dict[str, str]],
-            path: pathlib.Path,
-            mode: str = "w"
-    ):
+    def dump_jsonl(data: List[Dict[str, str]], path: pathlib.Path, mode: str = "w"):
         """Save a list of dictionaries to a jsonl.
 
         Parameters

--- a/tests/data/jats_article.xml
+++ b/tests/data/jats_article.xml
@@ -8,6 +8,7 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
     <front>
         <journal-meta>
+            <journal-id journal-id-type="nlm-ta">Journal NLM TA</journal-id>
             <journal-id journal-id-type="pmc">Journal ID PMC</journal-id>
             <journal-id journal-id-type="pubmed">Journal ID PubMed</journal-id>
             <journal-id journal-id-type="publisher">Journal ID Publisher</journal-id>

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -5,15 +5,15 @@ import pytest
 import responses
 from requests.exceptions import HTTPError
 
+from bluesearch.database.topic import extract_pubmed_id_from_pmc_file
 from bluesearch.database.topic import (
-    extract_pubmed_id_from_pmc_file,
-    request_mesh_from_nlm_ta,
-    request_mesh_from_pubmed_id,
+    request_mesh_from_nlm_ta as request_mesh_from_nlm_ta_decorated,
 )
+from bluesearch.database.topic import request_mesh_from_pubmed_id
 
 # This function uses caching through @lru_cache. We want remove caching logic
 # during tests.
-request_mesh_from_nlm_ta = request_mesh_from_nlm_ta.__wrapped__
+request_mesh_from_nlm_ta = request_mesh_from_nlm_ta_decorated.__wrapped__
 
 
 class TestGetMeshFromNlmTa:
@@ -40,7 +40,7 @@ class TestGetMeshFromNlmTa:
         responses.add(
             responses.GET,
             (
-                'https://www.ncbi.nlm.nih.gov/nlmcatalog?'
+                "https://www.ncbi.nlm.nih.gov/nlmcatalog?"
                 'term="Trauma Surg And Acute Care Open"[ta]&report=xml&format=text'
             ),
             body=body,

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -1,3 +1,19 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 import logging
 import re
 from unittest.mock import Mock

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -351,3 +351,5 @@ def test_get_pubmedid(test_data_path):
     path = test_data_path / "jats_article.xml"
     pubmed_id = extract_pubmed_id_from_pmc_file(path)
     assert pubmed_id == "PMID"
+
+

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -11,6 +11,10 @@ from bluesearch.database.topic import (
     request_mesh_from_pubmed_id,
 )
 
+# This function uses caching through @lru_cache. We want remove caching logic
+# during tests.
+request_mesh_from_nlm_ta = request_mesh_from_nlm_ta.__wrapped__
+
 
 class TestGetMeshFromNlmTa:
     @pytest.mark.network

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -351,5 +351,3 @@ def test_get_pubmedid(test_data_path):
     path = test_data_path / "jats_article.xml"
     pubmed_id = extract_pubmed_id_from_pmc_file(path)
     assert pubmed_id == "PMID"
-
-

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 from bluesearch.database.topic import (
     extract_pubmed_id_from_pmc_file,
-    request_mesh_from_journal_title,
+    request_mesh_from_nlm_ta,
     request_mesh_from_pubmed_id,
 )
 
@@ -22,7 +22,7 @@ class TestGetMeshFromNlmTa:
             "Wounds and Injuries",
         }
 
-        mesh = request_mesh_from_journal_title(nlm_ta)
+        mesh = request_mesh_from_nlm_ta(nlm_ta)
 
         assert mesh is not None
         assert len(mesh) == 3
@@ -74,13 +74,13 @@ class TestGetMeshFromNlmTa:
             },
         ]
 
-        mesh = request_mesh_from_journal_title("Trauma Surgery And Acute Care Open")
+        mesh = request_mesh_from_nlm_ta("Trauma Surgery And Acute Care Open")
         assert mesh == expected_output
 
     def test_ampersands_are_flagged(self):
         nlm_ta = "Title with &#x0201c;ampersands&#x0201d"
         with pytest.raises(ValueError, match="Ampersands not allowed"):
-            request_mesh_from_journal_title(nlm_ta)
+            request_mesh_from_nlm_ta(nlm_ta)
 
     @responses.activate
     def test_unexpected_response_doc_header_flagged(self):
@@ -90,7 +90,7 @@ class TestGetMeshFromNlmTa:
             body="should start with a fixed header",
         )
         with pytest.raises(RuntimeError, match="Unexpected response"):
-            request_mesh_from_journal_title("Some title")
+            request_mesh_from_nlm_ta("Some title")
 
     @responses.activate
     def test_unexpected_response_doc_footer_flagged(self):
@@ -106,7 +106,7 @@ class TestGetMeshFromNlmTa:
             body=f"{header}the footer is missing though",
         )
         with pytest.raises(RuntimeError, match="Unexpected response"):
-            request_mesh_from_journal_title("Some title")
+            request_mesh_from_nlm_ta("Some title")
 
     @responses.activate
     def test_no_nlm_ta_found_gives_none(self):
@@ -125,7 +125,7 @@ class TestGetMeshFromNlmTa:
             re.compile(""),
             body=f"{header}{body}{footer}",
         )
-        mesh = request_mesh_from_journal_title("Some title")
+        mesh = request_mesh_from_nlm_ta("Some title")
         assert mesh is None
 
     @responses.activate
@@ -145,7 +145,7 @@ class TestGetMeshFromNlmTa:
             body=f"{header}{body}{footer}",
         )
         with pytest.raises(ParseError, match="The parsing did not work"):
-            request_mesh_from_journal_title("Some title")
+            request_mesh_from_nlm_ta("Some title")
 
     @responses.activate
     def test_root_tag_is_checked(self):
@@ -166,7 +166,7 @@ class TestGetMeshFromNlmTa:
         with pytest.raises(
             RuntimeError, match="Expected to find the NCBICatalogRecord tag"
         ):
-            request_mesh_from_journal_title("Some title")
+            request_mesh_from_nlm_ta("Some title")
 
 
 @responses.activate

--- a/tests/unit/database/test_topic.py
+++ b/tests/unit/database/test_topic.py
@@ -7,7 +7,7 @@ from requests.exceptions import HTTPError
 
 from bluesearch.database.topic import (
     extract_pubmed_id_from_pmc_file,
-    request_mesh_from_nlm_ta,
+    request_mesh_from_journal_title,
     request_mesh_from_pubmed_id,
 )
 
@@ -15,14 +15,14 @@ from bluesearch.database.topic import (
 class TestGetMeshFromNlmTa:
     @pytest.mark.network
     def test_real_request_works(self):
-        nlm_ta = "Trauma Surg Acute Care Open"
+        nlm_ta = "Trauma Surgery And Acute Care Open"
         expected_descriptors = {
             "Critical Care",
             "Emergency Treatment",
             "Wounds and Injuries",
         }
 
-        mesh = request_mesh_from_nlm_ta(nlm_ta)
+        mesh = request_mesh_from_journal_title(nlm_ta)
 
         assert mesh is not None
         assert len(mesh) == 3
@@ -37,7 +37,7 @@ class TestGetMeshFromNlmTa:
             responses.GET,
             (
                 "https://www.ncbi.nlm.nih.gov/nlmcatalog?"
-                "term=Trauma Surg Acute Care Open[ta]&report=xml&format=text"
+                "term=Trauma Surgery And Acute Care Open[Title]&report=xml&format=text"
             ),
             body=body,
         )
@@ -74,13 +74,13 @@ class TestGetMeshFromNlmTa:
             },
         ]
 
-        mesh = request_mesh_from_nlm_ta("Trauma Surg Acute Care Open")
+        mesh = request_mesh_from_journal_title("Trauma Surgery And Acute Care Open")
         assert mesh == expected_output
 
     def test_ampersands_are_flagged(self):
         nlm_ta = "Title with &#x0201c;ampersands&#x0201d"
         with pytest.raises(ValueError, match="Ampersands not allowed"):
-            request_mesh_from_nlm_ta(nlm_ta)
+            request_mesh_from_journal_title(nlm_ta)
 
     @responses.activate
     def test_unexpected_response_doc_header_flagged(self):
@@ -90,7 +90,7 @@ class TestGetMeshFromNlmTa:
             body="should start with a fixed header",
         )
         with pytest.raises(RuntimeError, match="Unexpected response"):
-            request_mesh_from_nlm_ta("Some title")
+            request_mesh_from_journal_title("Some title")
 
     @responses.activate
     def test_unexpected_response_doc_footer_flagged(self):
@@ -106,7 +106,7 @@ class TestGetMeshFromNlmTa:
             body=f"{header}the footer is missing though",
         )
         with pytest.raises(RuntimeError, match="Unexpected response"):
-            request_mesh_from_nlm_ta("Some title")
+            request_mesh_from_journal_title("Some title")
 
     @responses.activate
     def test_no_nlm_ta_found_gives_none(self):
@@ -125,7 +125,7 @@ class TestGetMeshFromNlmTa:
             re.compile(""),
             body=f"{header}{body}{footer}",
         )
-        mesh = request_mesh_from_nlm_ta("Some title")
+        mesh = request_mesh_from_journal_title("Some title")
         assert mesh is None
 
     @responses.activate
@@ -145,7 +145,7 @@ class TestGetMeshFromNlmTa:
             body=f"{header}{body}{footer}",
         )
         with pytest.raises(ParseError, match="The parsing did not work"):
-            request_mesh_from_nlm_ta("Some title")
+            request_mesh_from_journal_title("Some title")
 
     @responses.activate
     def test_root_tag_is_checked(self):
@@ -166,7 +166,7 @@ class TestGetMeshFromNlmTa:
         with pytest.raises(
             RuntimeError, match="Expected to find the NCBICatalogRecord tag"
         ):
-            request_mesh_from_nlm_ta("Some title")
+            request_mesh_from_journal_title("Some title")
 
 
 @responses.activate

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -1,3 +1,19 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 import argparse
 import inspect
 import pathlib

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -23,7 +23,7 @@ import pytest
 
 from bluesearch.database.article import Article
 from bluesearch.entrypoint.database.parent import main
-from bluesearch.entrypoint.database.parse import filter_files, iter_parsers
+from bluesearch.entrypoint.database.parse import iter_parsers
 
 
 @pytest.mark.parametrize(
@@ -166,32 +166,3 @@ def test_dry_run(capsys):
     main(["parse", "cord19-json", input_path, "parsed/", "--dry-run"])
     captured = capsys.readouterr()
     assert captured.out == "tests/data/cord19_v35/metadata.csv\n"
-
-
-def test_filtering_recursive(tmp_path):
-    input_path = Path("tests/data/cord19_v35/document_parses/pdf_json/")
-    inputs = filter_files(input_path, recursive=True)
-    filenames = sorted(x.name for x in inputs)
-    expected = [
-        "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
-        "5f267fa1ef3a65e239aa974329e935a4d93dafd2.json",
-    ]
-    assert filenames == expected
-
-
-def test_filtering(tmp_path):
-    input_path = Path("tests/data/cord19_v35/")
-    inputs = filter_files(input_path, recursive=True, match_filename=r"[a-z0-9]+\.json")
-    filenames = sorted(x.name for x in inputs)
-    expected = [
-        "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
-        "5f267fa1ef3a65e239aa974329e935a4d93dafd2.json",
-    ]
-    assert filenames == expected
-
-
-def test_filtering_empty(tmp_path):
-    message = "Value for argument 'match-filename' should not be empty!"
-    input_path = Path("tests/data/cord19_v35/")
-    with pytest.raises(ValueError, match=message):
-        _ = filter_files(input_path, recursive=True, match_filename="")

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -1,3 +1,19 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 import json
 import logging
 from argparse import ArgumentError

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -7,7 +7,7 @@ import pytest
 
 from bluesearch.database.article import Article
 from bluesearch.entrypoint.database.parent import main
-from bluesearch.entrypoint.database.parse import iter_parsers, filter_files
+from bluesearch.entrypoint.database.parse import filter_files, iter_parsers
 
 
 @pytest.mark.parametrize(
@@ -165,11 +165,7 @@ def test_filtering_recursive(tmp_path):
 
 def test_filtering(tmp_path):
     input_path = Path("tests/data/cord19_v35/")
-    inputs = filter_files(
-        input_path,
-        recursive=True,
-        match_filename=r"[a-z0-9]+\.json"
-    )
+    inputs = filter_files(input_path, recursive=True, match_filename=r"[a-z0-9]+\.json")
     filenames = sorted(x.name for x in inputs)
     expected = [
         "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
@@ -182,8 +178,4 @@ def test_filtering_empty(tmp_path):
     message = "Value for argument 'match-filename' should not be empty!"
     input_path = Path("tests/data/cord19_v35/")
     with pytest.raises(ValueError, match=message):
-        _ = filter_files(
-            input_path,
-            recursive=True,
-            match_filename=""
-        )
+        _ = filter_files(input_path, recursive=True, match_filename="")

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -24,7 +24,7 @@ from bluesearch.entrypoint.database import topic_extract
 from bluesearch.utils import JSONL
 
 TOPIC_EXTRACT_PARAMS = {
-    "input_source",
+    "source",
     "input_path",
     "output_file",
     "match_filename",
@@ -41,7 +41,7 @@ def test_init_parser():
     assert vars(args).keys() == TOPIC_EXTRACT_PARAMS
 
     # Test the values
-    assert args.input_source == "pmc"
+    assert args.source == "pmc"
     assert args.input_path == pathlib.Path("/path/to/input")
     assert args.output_file == pathlib.Path("/path/to/output")
     assert args.match_filename is None
@@ -59,7 +59,7 @@ def test_run_arguments():
 def test_input_path_not_correct(caplog):
     with caplog.at_level(logging.ERROR):
         exit_code = topic_extract.run(
-            input_source="pmc",
+            source="pmc",
             input_path=pathlib.Path("wrong_directory/"),
             output_file=pathlib.Path(""),
             match_filename=None,
@@ -75,7 +75,7 @@ def test_wrong_source(test_data_path, caplog, tmp_path):
     pmc_path = test_data_path / "jats_article.xml"
     with caplog.at_level(logging.ERROR):
         exit_code = topic_extract.run(
-            input_source="wrong_type",
+            source="wrong_type",
             input_path=pmc_path,
             output_file=tmp_path,
             match_filename=None,
@@ -90,7 +90,7 @@ def test_wrong_source(test_data_path, caplog, tmp_path):
 def test_dry_run(test_data_path, capsys, tmp_path):
     pmc_path = test_data_path / "jats_article.xml"
     exit_code = topic_extract.run(
-        input_source="pmc",
+        source="pmc",
         input_path=pmc_path,
         output_file=tmp_path,
         match_filename=None,
@@ -114,7 +114,7 @@ def test_pmc_source(test_data_path, capsys, monkeypatch, tmp_path):
     )
 
     exit_code = topic_extract.run(
-        input_source="pmc",
+        source="pmc",
         input_path=pmc_path,
         output_file=output_jsonl,
         match_filename=None,
@@ -140,7 +140,7 @@ def test_pmc_source(test_data_path, capsys, monkeypatch, tmp_path):
 
     # Test overwrite
     exit_code = topic_extract.run(
-        input_source="pmc",
+        source="pmc",
         input_path=pmc_path,
         output_file=output_jsonl,
         match_filename=None,
@@ -154,7 +154,7 @@ def test_pmc_source(test_data_path, capsys, monkeypatch, tmp_path):
 
     # Test appending
     exit_code = topic_extract.run(
-        input_source="pmc",
+        source="pmc",
         input_path=pmc_path,
         output_file=output_jsonl,
         match_filename=None,

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -1,3 +1,19 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
 import argparse
 import inspect
 import logging

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -16,9 +16,11 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import json
 import pathlib
+from typing import Any
 
 import h5py
 import numpy as np
@@ -345,7 +347,7 @@ class TestH5:
 def test_load_save_jsonl(tmpdir):
     path = pathlib.Path(str(tmpdir)) / "file.jsonl"
 
-    li = [{"a": 1, "b": "cc"}, {"k": 23}]
+    li: list[dict[str, Any]] = [{"a": 1, "b": "cc"}, {"k": 23}]
     JSONL.dump_jsonl(li, path)
     lo = JSONL.load_jsonl(path)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -32,10 +32,40 @@ from bluesearch.utils import (
     JSONL,
     Timer,
     check_entity_type_consistency,
+    find_files,
     get_available_spacy_models,
     load_spacy_model,
 )
 
+
+class TestFindFiles:
+    def test_filtering_recursive(tmp_path):
+        input_path = pathlib.Path("tests/data/cord19_v35/document_parses/pdf_json/")
+        inputs = find_files(input_path, recursive=True)
+        filenames = sorted(x.name for x in inputs)
+        expected = [
+            "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
+            "5f267fa1ef3a65e239aa974329e935a4d93dafd2.json",
+        ]
+        assert filenames == expected
+
+
+    def test_filtering(tmp_path):
+        input_path = pathlib.Path("tests/data/cord19_v35/")
+        inputs = find_files(input_path, recursive=True, match_filename=r"[a-z0-9]+\.json")
+        filenames = sorted(x.name for x in inputs)
+        expected = [
+            "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
+            "5f267fa1ef3a65e239aa974329e935a4d93dafd2.json",
+        ]
+        assert filenames == expected
+
+
+    def test_filtering_empty(tmp_path):
+        message = "Value for argument 'match-filename' should not be empty!"
+        input_path = pathlib.Path("tests/data/cord19_v35/")
+        with pytest.raises(ValueError, match=message):
+            _ = find_files(input_path, recursive=True, match_filename="")
 
 class TestTimer:
     def test_errors(self):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -49,10 +49,11 @@ class TestFindFiles:
         ]
         assert filenames == expected
 
-
     def test_filtering(tmp_path):
         input_path = pathlib.Path("tests/data/cord19_v35/")
-        inputs = find_files(input_path, recursive=True, match_filename=r"[a-z0-9]+\.json")
+        inputs = find_files(
+            input_path, recursive=True, match_filename=r"[a-z0-9]+\.json"
+        )
         filenames = sorted(x.name for x in inputs)
         expected = [
             "16e82ce0e0c8a1b36497afc0d4392b4fe21eb174.json",
@@ -60,12 +61,12 @@ class TestFindFiles:
         ]
         assert filenames == expected
 
-
     def test_filtering_empty(tmp_path):
         message = "Value for argument 'match-filename' should not be empty!"
         input_path = pathlib.Path("tests/data/cord19_v35/")
         with pytest.raises(ValueError, match=message):
             _ = find_files(input_path, recursive=True, match_filename="")
+
 
 class TestTimer:
     def test_errors(self):


### PR DESCRIPTION
Fixes #523.

## Description

- Creation of CLI `bbs_database topic-extract`
- Handle PMC source (for now only extract journal topic)
- Creation of a function `filter_files` used by `bbs_database parse` and `bbs_database topic-extract` CLI commands.

## Still to be discuss

- Sometimes, we do not have any `NLM Title Abbreviation`, should we extracting another info (for example `Journal title`) when it is the case ?
- Do we want to handle article topics and when ? 
- Currently, we extract `name` of the MeSH, could it be possible to take the IDs instead ?

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
