### PR TITLE
Ignore deprecation warning emitted by the docker package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -138,6 +138,7 @@ commands =
 testpaths = tests
 filterwarnings =
     error
+    ignore::DeprecationWarning:docker.*:
 addopts =
     --cov
     --cov-config=tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -136,6 +136,7 @@ commands =
 
 [pytest]
 testpaths = tests
+# reason for the ignore: https://github.com/docker/docker-py/issues/2928
 filterwarnings =
     error
     ignore::DeprecationWarning:docker.*:


### PR DESCRIPTION
This should be a temporary fix for https://github.com/docker/docker-py/issues/2928.