### PR TITLE
Use modern type annotations (PEP 604 + PEP 585)

### DIFF
--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -23,7 +23,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Sequence
+from typing import Generator, Iterable, Optional, Sequence, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
@@ -851,11 +851,11 @@ class Article(DataClassJSONMixin):
     title: str
     authors: Sequence[str]
     abstract: Sequence[str]
-    section_paragraphs: Sequence[tuple[str, str]]
-    pubmed_id: str | None = None
-    pmc_id: str | None = None
-    doi: str | None = None
-    uid: str | None = None
+    section_paragraphs: Sequence[Tuple[str, str]]
+    pubmed_id: Optional[str] = None
+    pmc_id: Optional[str] = None
+    doi: Optional[str] = None
+    uid: Optional[str] = None
 
     @classmethod
     def parse(cls, parser: ArticleParser) -> Article:

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -23,7 +23,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Sequence, Tuple
+from typing import Generator, Iterable, Sequence
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
@@ -851,7 +851,7 @@ class Article(DataClassJSONMixin):
     title: str
     authors: Sequence[str]
     abstract: Sequence[str]
-    section_paragraphs: Sequence[Tuple[str, str]]
+    section_paragraphs: Sequence[tuple[str, str]]
     pubmed_id: str | None = None
     pmc_id: str | None = None
     doi: str | None = None

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -23,7 +23,7 @@ import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Generator, Iterable, Optional, Sequence, Tuple
+from typing import Generator, Iterable, Sequence, Tuple
 from xml.etree.ElementTree import Element  # nosec
 
 from defusedxml import ElementTree
@@ -81,7 +81,7 @@ class ArticleParser(ABC):
         """
 
     @property
-    def pubmed_id(self) -> Optional[str]:
+    def pubmed_id(self) -> str | None:
         """Get Pubmed ID.
 
         Returns
@@ -92,7 +92,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def pmc_id(self) -> Optional[str]:
+    def pmc_id(self) -> str | None:
         """Get PMC ID.
 
         Returns
@@ -103,7 +103,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def doi(self) -> Optional[str]:
+    def doi(self) -> str | None:
         """Get DOI.
 
         Returns
@@ -114,7 +114,7 @@ class ArticleParser(ABC):
         return None
 
     @property
-    def uid(self) -> Optional[str]:
+    def uid(self) -> str | None:
         """Generate unique ID of the article based on different identifiers.
 
         Returns
@@ -231,7 +231,7 @@ class JATSXMLParser(ArticleParser):
                 yield "Table Caption", caption
 
     @property
-    def pubmed_id(self) -> Optional[str]:
+    def pubmed_id(self) -> str | None:
         """Get Pubmed ID.
 
         Returns
@@ -242,7 +242,7 @@ class JATSXMLParser(ArticleParser):
         return self.ids.get("pmid")
 
     @property
-    def pmc_id(self) -> Optional[str]:
+    def pmc_id(self) -> str | None:
         """Get PMC ID.
 
         Returns
@@ -253,7 +253,7 @@ class JATSXMLParser(ArticleParser):
         return self.ids.get("pmc")
 
     @property
-    def doi(self) -> Optional[str]:
+    def doi(self) -> str | None:
         """Get DOI.
 
         Returns
@@ -477,7 +477,7 @@ class PubMedXMLParser(ArticleParser):
         return ()
 
     @property
-    def pubmed_id(self) -> Optional[str]:
+    def pubmed_id(self) -> str | None:
         """Get Pubmed ID.
 
         Returns
@@ -489,7 +489,7 @@ class PubMedXMLParser(ArticleParser):
         return pubmed_id.text
 
     @property
-    def pmc_id(self) -> Optional[str]:
+    def pmc_id(self) -> str | None:
         """Get PMC ID.
 
         Returns
@@ -503,7 +503,7 @@ class PubMedXMLParser(ArticleParser):
         return None if pmc_id is None else pmc_id.text
 
     @property
-    def doi(self) -> Optional[str]:
+    def doi(self) -> str | None:
         """Get DOI.
 
         Returns
@@ -610,7 +610,7 @@ class CORD19ArticleParser(ArticleParser):
             yield "Caption", ref_entry["text"]
 
     @property
-    def pmc_id(self) -> Optional[str]:
+    def pmc_id(self) -> str | None:
         """Get PMC ID.
 
         Returns
@@ -852,10 +852,10 @@ class Article(DataClassJSONMixin):
     authors: Sequence[str]
     abstract: Sequence[str]
     section_paragraphs: Sequence[Tuple[str, str]]
-    pubmed_id: Optional[str] = None
-    pmc_id: Optional[str] = None
-    doi: Optional[str] = None
-    uid: Optional[str] = None
+    pubmed_id: str | None = None
+    pmc_id: str | None = None
+    doi: str | None = None
+    uid: str | None = None
 
     @classmethod
     def parse(cls, parser: ArticleParser) -> Article:

--- a/src/bluesearch/database/mining_cache.py
+++ b/src/bluesearch/database/mining_cache.py
@@ -1,5 +1,3 @@
-"""Module for the Database Creation."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,13 +14,13 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Module for the Database Creation."""
 
 import io
 import logging
 import multiprocessing as mp
 import queue
 import traceback
-from typing import Dict, List
 
 import sqlalchemy
 import torch
@@ -407,19 +405,19 @@ class CreateMiningCache:
         )
 
         # Flags to let the workers know there won't be any new tasks.
-        can_finish: Dict[str, mp.synchronize.Event] = {
+        can_finish: dict[str, mp.synchronize.Event] = {
             etype: mp.Event() for etype in self.ee_models_paths
         }
 
         # Prepare the task queues for the workers - one task queue per model.
-        task_queues: Dict[str, mp.Queue] = {
+        task_queues: dict[str, mp.Queue] = {
             etype: mp.Queue() for etype in self.ee_models_paths
         }
 
         # Spawn the workers according to `workers_per_model`.
         self.logger.info("Spawning the worker processes")
         worker_processes = []
-        workers_by_queue: Dict[str, List[mp.Process]] = {
+        workers_by_queue: dict[str, list[mp.Process]] = {
             queue_name: [] for queue_name in task_queues
         }
         for etype, model_path in self.ee_models_paths.items():
@@ -487,7 +485,7 @@ class CreateMiningCache:
         self.logger.info("No more new tasks, just waiting for the workers to finish")
         # We'll transfer finished workers from `worker_processes`
         # to `finished_workers`. We're done when `worker_processes` is empty.
-        finished_workers: List[mp.Process] = []
+        finished_workers: list[mp.Process] = []
         while len(worker_processes) > 0:
             self.logger.debug(
                 f"Status: {len(worker_processes)} workers still alive, "

--- a/src/bluesearch/database/mining_cache.py
+++ b/src/bluesearch/database/mining_cache.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Module for the Database Creation."""
+from __future__ import annotations
 
 import io
 import logging

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -21,7 +21,7 @@ import html
 import logging
 import pathlib
 from functools import lru_cache
-from typing import Iterable, List
+from typing import Iterable
 from xml.etree.ElementTree import Element  # nosec
 
 import requests
@@ -261,7 +261,7 @@ def _parse_mesh_from_pubmed(mesh_headings: Iterable[Element]) -> list[dict]:
 # PMC source
 def get_topics_for_pmc_article(
     pmc_path: pathlib.Path | str,
-) -> List[str] | None:
+) -> list[str] | None:
     """Extract journal topics of a PMC article.
 
     Parameters
@@ -271,7 +271,7 @@ def get_topics_for_pmc_article(
 
     Returns
     -------
-    journal_topics : Optional[list[str]]
+    journal_topics : list[str] | None
         Journal topics for the given article.
     """
     # Determine journal title

--- a/src/bluesearch/embedding_models.py
+++ b/src/bluesearch/embedding_models.py
@@ -1,5 +1,3 @@
-"""Model handling sentences embeddings."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,13 +14,14 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Model handling sentences embeddings."""
+from __future__ import annotations
 
 import logging
 import multiprocessing as mp
 import pathlib
 import pickle  # nosec
 from abc import ABC, abstractmethod
-from typing import Optional, Union
 
 import numpy as np
 import sentence_transformers
@@ -299,7 +298,7 @@ def compute_database_embeddings(connection, model, indices, batch_size=10):
 
 def get_embedding_model(
     model_name_or_class: str,
-    checkpoint_path: Optional[Union[pathlib.Path, str]] = None,
+    checkpoint_path: pathlib.Path | str | None = None,
     device: str = "cpu",
 ) -> EmbeddingModel:
     """Load a sentence embedding model from its name or its class and checkpoint.

--- a/src/bluesearch/entrypoint/_helper.py
+++ b/src/bluesearch/entrypoint/_helper.py
@@ -1,5 +1,3 @@
-"""Helper functions for server entry points."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,6 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Helper functions for server entry points."""
+from __future__ import annotations
 
 import argparse
 import collections
@@ -23,7 +23,7 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Dict, Optional, Sequence
+from typing import Dict, Sequence
 
 from dotenv import load_dotenv
 
@@ -179,7 +179,7 @@ class CombinedHelpFormatter(argparse.HelpFormatter):
 def parse_args_or_environment(
     parser: argparse.ArgumentParser,
     env_variable_names: Dict[str, str],
-    argv: Optional[Sequence[str]] = None,
+    argv: Sequence[str] | None = None,
 ) -> argparse.Namespace:
     """Parse CLI arguments with some defaults specified in the environment.
 

--- a/src/bluesearch/entrypoint/_helper.py
+++ b/src/bluesearch/entrypoint/_helper.py
@@ -23,7 +23,7 @@ import logging
 import os
 import sys
 import textwrap
-from typing import Dict, Sequence
+from typing import Sequence
 
 from dotenv import load_dotenv
 
@@ -178,7 +178,7 @@ class CombinedHelpFormatter(argparse.HelpFormatter):
 
 def parse_args_or_environment(
     parser: argparse.ArgumentParser,
-    env_variable_names: Dict[str, str],
+    env_variable_names: dict[str, str],
     argv: Sequence[str] | None = None,
 ) -> argparse.Namespace:
     """Parse CLI arguments with some defaults specified in the environment.

--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -1,9 +1,11 @@
 """Module implementing the high level CLI logic."""
+from __future__ import annotations
+
 import argparse
 import logging
 import sys
 from collections import namedtuple
-from typing import Optional, Sequence
+from typing import Sequence
 
 from bluesearch.entrypoint.database import (
     add,
@@ -33,7 +35,7 @@ def _setup_logging(logging_level: int) -> None:
     root_logger.addHandler(handler)
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Run CLI.
 
     This is the main entrypoint that defines different commands

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -15,12 +15,14 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Parsing articles."""
+from __future__ import annotations
+
 import argparse
 import json
 import logging
 import warnings
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Iterator
 
 from defusedxml import ElementTree
 
@@ -145,7 +147,7 @@ def run(
     input_type: str,
     input_path: Path,
     output_dir: Path,
-    match_filename: Optional[str],
+    match_filename: str | None,
     recursive: bool,
     dry_run: bool,
 ) -> int:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -21,7 +21,7 @@ import argparse
 import datetime
 import logging
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +117,7 @@ def run(
     source: str,
     input_path: Path,
     output_file: Path,
-    match_filename: Optional[str],
+    match_filename: str | None,
     recursive: bool,
     overwrite: bool,
     dry_run: bool,

--- a/src/bluesearch/entrypoint/embeddings.py
+++ b/src/bluesearch/entrypoint/embeddings.py
@@ -16,12 +16,12 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+from __future__ import annotations
 
 import argparse
 import logging
 import pathlib
 import sys
-from typing import Optional
 
 import numpy as np
 import sqlalchemy
@@ -191,7 +191,7 @@ def run_compute_embeddings(argv=None):
     # Path preparation and checking
     out_file = pathlib.Path(args.outfile)
     temp_dir = None if args.temp_dir is None else pathlib.Path(args.temp_dir)
-    checkpoint_path: Optional[pathlib.Path] = None
+    checkpoint_path: pathlib.Path | None = None
     if args.checkpoint is not None:
         checkpoint_path = pathlib.Path(args.checkpoint)
     indices_path = (

--- a/src/bluesearch/entrypoint/mining_server.py
+++ b/src/bluesearch/entrypoint/mining_server.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """The entrypoint script for the mining server."""
+from __future__ import annotations
 
 import logging
 import pathlib

--- a/src/bluesearch/entrypoint/mining_server.py
+++ b/src/bluesearch/entrypoint/mining_server.py
@@ -1,5 +1,3 @@
-"""The entrypoint script for the mining server."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""The entrypoint script for the mining server."""
 
 import logging
 import pathlib

--- a/src/bluesearch/mining/eval.py
+++ b/src/bluesearch/mining/eval.py
@@ -1,5 +1,3 @@
-"""Classes and functions for evaluating mining models predictions."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,13 +14,15 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Classes and functions for evaluating mining models predictions."""
+from __future__ import annotations
 
 import copy
 import json
 import string
 from collections import OrderedDict
 from pathlib import Path
-from typing import Optional, Union, overload
+from typing import overload
 
 import numpy as np
 import pandas as pd
@@ -369,7 +369,7 @@ def ner_report(
     iob_true: pd.Series,
     iob_pred: pd.Series,
     mode: str = "entity",
-    etypes_map: Optional[dict] = None,
+    etypes_map: dict | None = None,
     return_dict: Literal[False] = ...,
 ) -> str:
     ...
@@ -380,7 +380,7 @@ def ner_report(
     iob_true: pd.Series,
     iob_pred: pd.Series,
     mode: str = "entity",
-    etypes_map: Optional[dict] = None,
+    etypes_map: dict | None = None,
     *,
     return_dict: Literal[True],
 ) -> OrderedDict:
@@ -391,9 +391,9 @@ def ner_report(
     iob_true: pd.Series,
     iob_pred: pd.Series,
     mode: str = "entity",
-    etypes_map: Optional[dict] = None,
+    etypes_map: dict | None = None,
     return_dict: bool = False,
-) -> Union[str, OrderedDict]:
+) -> str | OrderedDict:
     """Build a summary report showing the main ner evaluation metrics.
 
     Evaluation is performed according to the definitions of "errors" from [1].
@@ -417,7 +417,7 @@ def ner_report(
 
     Returns
     -------
-    report : Union[str, OrderedDict]
+    report : str | OrderedDict
         Text summary of the precision, recall, F1 score for each entity type.
         Dictionary returned if output_dict is True. Dictionary has the
         following structure
@@ -505,9 +505,9 @@ def ner_errors(
     iob_pred: pd.Series,
     tokens: pd.Series,
     mode: str = "entity",
-    etypes_map: Optional[dict] = None,
+    etypes_map: dict | None = None,
     return_dict: bool = False,
-) -> Union[str, OrderedDict]:
+) -> str | OrderedDict:
     """Build a summary report for the named entity recognition.
 
     False positives and false negatives for each entity type are collected.
@@ -534,7 +534,7 @@ def ner_errors(
 
     Returns
     -------
-    report : Union[str, OrderedDict]
+    report : str | OrderedDict
         Text summary of the precision, recall, F1 score for each entity type.
         Dictionary returned if output_dict is True. Dictionary has the
         following structure
@@ -616,7 +616,7 @@ def ner_errors(
 def ner_confusion_matrix(
     iob_true: pd.Series,
     iob_pred: pd.Series,
-    normalize: Optional[str] = None,
+    normalize: str | None = None,
     mode: str = "entity",
 ) -> pd.DataFrame:
     """Compute confusion matrix to evaluate the accuracy of a NER model.

--- a/src/bluesearch/server/mining_server.py
+++ b/src/bluesearch/server/mining_server.py
@@ -1,5 +1,3 @@
-"""The mining server."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,9 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""The mining server."""
 
 import io
-from typing import Any, Dict, Iterable, Tuple
+from typing import Any, Iterable
 
 import pandas as pd
 import spacy
@@ -59,7 +58,7 @@ class MiningServer(Flask):
         self.models_libs = models_libs
 
         self.logger.info("Loading the NER models")
-        self.ee_models: Dict[str, spacy.language.Language] = {}
+        self.ee_models: dict[str, spacy.language.Language] = {}
         self.logger.debug(f"EE models available:\n{str(self.models_libs['ee'])}")
         for entity_type, model_path in models_libs["ee"].items():
             self.logger.info(f"Entity type {entity_type}: loading model {model_path}")
@@ -252,7 +251,7 @@ class MiningServer(Flask):
 
             schema_df = self.read_df_from_str(schema_str)
 
-            texts: Iterable[Tuple[str, Dict[Any, Any]]] = [(text, {})]
+            texts: Iterable[tuple[str, dict[Any, Any]]] = [(text, {})]
             df_all, etypes_na = self.mine_texts(
                 texts=texts, schema_df=schema_df, debug=debug
             )

--- a/src/bluesearch/server/mining_server.py
+++ b/src/bluesearch/server/mining_server.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """The mining server."""
+from __future__ import annotations
 
 import io
 from typing import Any, Iterable

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -24,7 +24,7 @@ import pathlib
 import re
 import time
 import warnings
-from typing import Any, Dict, List, Set, Union
+from typing import Any, Dict, List, Set
 
 import h5py
 import numpy as np
@@ -541,7 +541,7 @@ class MissingEnvironmentVariable(Exception):
     """Exception for missing environment variables."""
 
 
-def check_entity_type_consistency(model_path: Union[str, pathlib.Path]) -> bool:
+def check_entity_type_consistency(model_path: str | pathlib.Path) -> bool:
     """Check that entity type of the model name is the same as in the ner pipe.
 
     Parameters
@@ -589,7 +589,7 @@ def check_entity_type_consistency(model_path: Union[str, pathlib.Path]) -> bool:
 
 
 def get_available_spacy_models(
-    data_and_models_dir: Union[str, pathlib.Path]
+    data_and_models_dir: str | pathlib.Path,
 ) -> Dict[str, pathlib.Path]:
     """List available spacy models for a given data directory.
 
@@ -628,7 +628,7 @@ def get_available_spacy_models(
 
 
 def load_spacy_model(
-    model_name: Union[str, pathlib.Path], device: str = "cpu", *args: Any, **kwargs: Any
+    model_name: str | pathlib.Path, device: str = "cpu", *args: Any, **kwargs: Any
 ) -> spacy.language.Language:
     """Spacy model load with informative error message.
 

--- a/src/bluesearch/utils.py
+++ b/src/bluesearch/utils.py
@@ -24,7 +24,7 @@ import pathlib
 import re
 import time
 import warnings
-from typing import Any, Dict, List, Set
+from typing import Any
 
 import h5py
 import numpy as np
@@ -243,11 +243,11 @@ class H5:
         if not h5_paths_temp:
             raise ValueError("No temporary h5 files provided.")
 
-        all_indices: Set[int] = set()
+        all_indices: set[int] = set()
         dim = None
         for path_temp in h5_paths_temp:
             with h5py.File(path_temp, "r") as f:
-                current_indices_set: Set[int] = set(f[f"{dataset_name}_indices"][:, 0])
+                current_indices_set: set[int] = set(f[f"{dataset_name}_indices"][:, 0])
                 current_dim = f[f"{dataset_name}"].shape[1]
 
                 if dim is None:
@@ -497,7 +497,7 @@ class JSONL:
 
     @staticmethod
     def dump_jsonl(
-        data: List[Dict[str, str]], path: pathlib.Path, overwrite: bool = True
+        data: list[dict[str, str]], path: pathlib.Path, overwrite: bool = True
     ):
         """Save a list of dictionaries to a jsonl.
 
@@ -590,7 +590,7 @@ def check_entity_type_consistency(model_path: str | pathlib.Path) -> bool:
 
 def get_available_spacy_models(
     data_and_models_dir: str | pathlib.Path,
-) -> Dict[str, pathlib.Path]:
+) -> dict[str, pathlib.Path]:
     """List available spacy models for a given data directory.
 
     Parameters

--- a/src/bluesearch/widgets/mining_schema.py
+++ b/src/bluesearch/widgets/mining_schema.py
@@ -1,5 +1,3 @@
-"""Implementation of the MiningSchma class."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Implementation of the MiningSchma class."""
 
 import warnings
 
@@ -69,7 +68,7 @@ class MiningSchema:
         }
         # Make sure there are no duplicates to begin with
         self.schema_df = self.schema_df.drop_duplicates(ignore_index=True)
-        # 'row' has type Dict[str, Any]. It is valid for append(). Ignoring the error.
+        # 'row' has type dict[str, Any]. It is valid for append(). Ignoring the error.
         self.schema_df = self.schema_df.append(row, ignore_index=True)  # type: ignore[arg-type]  # noqa
         # If there are any duplicates at this point, then it must have
         # come from the appended row.

--- a/src/bluesearch/widgets/mining_schema.py
+++ b/src/bluesearch/widgets/mining_schema.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Implementation of the MiningSchma class."""
+from __future__ import annotations
 
 import warnings
 

--- a/tests/unit/entrypoint/test__helper.py
+++ b/tests/unit/entrypoint/test__helper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 from typing import Sequence
 

--- a/tests/unit/entrypoint/test__helper.py
+++ b/tests/unit/entrypoint/test__helper.py
@@ -1,5 +1,5 @@
 import argparse
-from typing import Dict, Sequence
+from typing import Sequence
 
 import pytest
 
@@ -15,7 +15,7 @@ def test_parse_args_or_environment(monkeypatch):
 
     # --env-arg not provided at all
     argv: Sequence[str] = []
-    env_variable_names: Dict[str, str] = {}
+    env_variable_names: dict[str, str] = {}
     args = parse_args_or_environment(parser, env_variable_names, argv)
     assert "normal_arg" in args.__dict__
     assert "env_arg" not in args.__dict__

--- a/tests/unit/mining/test_attribute.py
+++ b/tests/unit/mining/test_attribute.py
@@ -1,5 +1,3 @@
-"""Tests covering attribute extraction."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,10 +14,10 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Tests covering attribute extraction."""
 
 import json
 from copy import deepcopy
-from typing import Dict, Set
 from unittest.mock import Mock
 
 import pandas as pd
@@ -675,8 +673,8 @@ class TestAttributeExtraction:
         assert expected == generated
 
     def test_iter_quantities_empty(self, extractor: AttributeExtractor):
-        measurement: Dict[str, str] = {}
-        expected: Set[str] = set()
+        measurement: dict[str, str] = {}
+        expected: set[str] = set()
         with pytest.warns(UserWarning) as warning_records:
             generated = set(extractor.iter_quantities(measurement))
         assert expected == generated

--- a/tests/unit/mining/test_attribute.py
+++ b/tests/unit/mining/test_attribute.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Tests covering attribute extraction."""
+from __future__ import annotations
 
 import json
 from copy import deepcopy

--- a/tests/unit/mining/test_pipeline.py
+++ b/tests/unit/mining/test_pipeline.py
@@ -1,5 +1,3 @@
-"""Collection of tests focused on the bluesearch.mining.pipeline module."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,8 +14,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Collection of tests focused on the bluesearch.mining.pipeline module."""
 
-from typing import Dict, List, Tuple
 from unittest.mock import Mock
 
 import pandas as pd
@@ -104,7 +102,7 @@ def test_without_relation(model_entities, debug, n_paragraphs):
         "in Brazil yesterday. And I am a filler too."
     )
 
-    models_relations: Dict[Tuple[str], List[REModel]] = {}
+    models_relations: dict[tuple[str], list[REModel]] = {}
     texts = n_paragraphs * [(text, {"important_parameter": 10})]
     df = run_pipeline(texts, model_entities, models_relations, debug)
 
@@ -143,7 +141,7 @@ def test_not_entity_label(model_entities):
 
     model_entities_m = Mock(spec=Language)
     model_entities_m.pipe.return_value = [(doc, {})]
-    models_relations: Dict[Tuple[str], List[REModel]] = {}
+    models_relations: dict[tuple[str], list[REModel]] = {}
 
     df_1 = run_pipeline(
         texts, model_entities_m, models_relations, excluded_entity_type="!"

--- a/tests/unit/mining/test_pipeline.py
+++ b/tests/unit/mining/test_pipeline.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Collection of tests focused on the bluesearch.mining.pipeline module."""
+from __future__ import annotations
 
 from unittest.mock import Mock
 

--- a/tests/unit/widgets/test_mining_widget.py
+++ b/tests/unit/widgets/test_mining_widget.py
@@ -1,5 +1,3 @@
-"""Tests covering the mining widget."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,11 +14,12 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Tests covering the mining widget."""
 
 import json
 from copy import copy
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -52,7 +51,7 @@ class MiningWidgetBot:
 
     def __init__(self, mining_widget, capsys, monkeypatch):
         self.mining_widget = mining_widget
-        self._display_cached: List[Any] = []
+        self._display_cached: list[Any] = []
         self._capsys = capsys
 
         monkeypatch.setattr(

--- a/tests/unit/widgets/test_mining_widget.py
+++ b/tests/unit/widgets/test_mining_widget.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Tests covering the mining widget."""
+from __future__ import annotations
 
 import json
 from copy import copy

--- a/tests/unit/widgets/test_search_widget.py
+++ b/tests/unit/widgets/test_search_widget.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 """Tests covering the search widget."""
+from __future__ import annotations
 
 import contextlib
 import json

--- a/tests/unit/widgets/test_search_widget.py
+++ b/tests/unit/widgets/test_search_widget.py
@@ -1,5 +1,3 @@
-"""Tests covering the search widget."""
-
 # Blue Brain Search is a text mining toolbox focused on scientific use cases.
 #
 # Copyright (C) 2020  Blue Brain Project, EPFL.
@@ -16,6 +14,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Tests covering the search widget."""
 
 import contextlib
 import json
@@ -24,7 +23,7 @@ import textwrap
 from copy import copy
 from functools import partial
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 from unittest.mock import Mock
 
 import ipywidgets
@@ -69,7 +68,7 @@ class SearchWidgetBot:
 
     def __init__(self, search_widget, capsys, monkeypatch, n_displays_per_result=4):
         self.search_widget = search_widget
-        self._display_cached: List[Any] = []
+        self._display_cached: list[Any] = []
         self._capsys = capsys
         self.n_displays_per_result = n_displays_per_result
 


### PR DESCRIPTION
## Description

This PR rewrites type annotations in `src/` and `tests/` to follow the new style introduced in [PEP 604](https://www.python.org/dev/peps/pep-0604/) and [PEP 585](https://www.python.org/dev/peps/pep-0585/). Basically, this means using:
- the shorthand `Type1 | Type2` to represent type union — so we get rid of `typing.Union` and `typing.Optional`
- the built-ins collection types instead of the generic duplicates from `typing` — so we get rid of the depracated `typing.Dict`, `typing.List`, `typing.Set`, ...


## How to test?

The output of 
-  `git grep -rIn "typing.*" src/  | sort -u`
- ` git grep -rIn "typing.*" tests/ | sort -u`
should show no trace of `Optional`, `Union`, `Set`, `Dict`, `List`, `Tuple`.

**NOTE** — There's only one exception to this cleanup I did, consisting in the class `Article` which inherits from `DataClassJSONMixin`. See ~https://github.com/lidatong/dataclasses-json/issues/327~ issue https://github.com/Fatal1ty/mashumaro/issues/65 (edit: the first issue was created in the wrong repo).

## Checklist

- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
