### PR TITLE
`generate_uid` raises `ValueError` if all ids are `None`

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,8 @@ Legend
 
 Latest
 ======
+- |Change| :code:`uid` generation raises :code:`ValueError` if all identifiers
+  are :code:`None`.
 - |Add| code to download :code:`arxiv` papers from a given date.
 - |Change| the behaviour of the entrypoint :code:`bbs_database download` when the
   specified :code:`--from-month` is too old and the source changed its structure of storing articles

--- a/src/bluesearch/database/identifiers.py
+++ b/src/bluesearch/database/identifiers.py
@@ -40,10 +40,17 @@ def generate_uid(identifiers: tuple[str | None, ...]) -> str | None:
     Returns
     -------
     str or None
-        A deterministic UID. The value is 'None' if all given identifiers are 'None'.
+        A deterministic UID.
+
+    Raises
+    ------
+    ValueError
+        If all identifiers are `None`.
     """
     if all(x is None for x in identifiers):
-        return None
+        raise ValueError(
+            f"Identifiers = {identifiers} are all `None`, UID cannot be computed."
+        )
     else:
         data = str(identifiers).encode()
         hashed = hashlib.md5(data).hexdigest()  # nosec

--- a/src/bluesearch/database/identifiers.py
+++ b/src/bluesearch/database/identifiers.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import hashlib
 
 
-def generate_uid(identifiers: tuple[str | None, ...]) -> str | None:
+def generate_uid(identifiers: tuple[str | None, ...]) -> str:
     """Generate a deterministic UID for the given paper identifiers.
 
     Papers with the same values for the given identifiers get the same UID.
@@ -39,7 +39,7 @@ def generate_uid(identifiers: tuple[str | None, ...]) -> str | None:
 
     Returns
     -------
-    str or None
+    str
         A deterministic UID.
 
     Raises

--- a/tests/unit/database/test_identifiers.py
+++ b/tests/unit/database/test_identifiers.py
@@ -41,6 +41,9 @@ class TestIdentifiers:
                 (None, "a"), "77f283f2e87b852ed7a881e6f638aa80", id="with-none-reverse"
             ),
             pytest.param((None, None), None, id="all-none"),
+            pytest.param(
+                (None, 0), "14536e026b2a39caf27f3da802e7fed6", id="none-and-zero"
+            ),
         ],
     )
     def test_generate_uid(self, identifiers, expected):
@@ -48,9 +51,14 @@ class TestIdentifiers:
         # this test checks that 'generate_uid(...)' is deterministic across platforms
         # and Python processes.
 
-        result = generate_uid(identifiers)
-        assert result == expected
+        if expected is None:
+            with pytest.raises(ValueError):
+                generate_uid(identifiers)
 
-        # Check determinism.
-        result_bis = generate_uid(identifiers)
-        assert result == result_bis
+        else:
+            result = generate_uid(identifiers)
+            assert result == expected
+
+            # Check determinism.
+            result_bis = generate_uid(identifiers)
+            assert result == result_bis


### PR DESCRIPTION
Partially fixes #507.

## Description

`generate_uid` now raises `ValueError` if all provided identifiers  are `None`.

## How to test?

See unit tests.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] All unit tests are passing.