### PR TITLE
Add the TopicInfo data structure

### DIFF
--- a/docs/source/api/bluesearch.database.rst
+++ b/docs/source/api/bluesearch.database.rst
@@ -14,6 +14,7 @@ Submodules
    bluesearch.database.mining_cache
    bluesearch.database.pdf
    bluesearch.database.topic
+   bluesearch.database.topic_info
 
 Module contents
 ---------------

--- a/docs/source/api/bluesearch.database.topic_info.rst
+++ b/docs/source/api/bluesearch.database.topic_info.rst
@@ -1,0 +1,7 @@
+bluesearch.database.topic\_info module
+======================================
+
+.. automodule:: bluesearch.database.topic_info
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,8 @@ Legend
 
 Latest
 ======
+- |Add| the :code:`bluesearch.database.topic_info.TopicInfo` class
+- |Add| the :code:`bluesearch.database.article.ArticleSource` enum class
 - |Add| extraction of journal and article topics for :code:`pubmed` papers
   through CLI command :code:`bbs_database topic-extract pubmed`.
 - |Add| extraction of journal topics for :code:`pmc` papers through CLI command

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -17,6 +17,7 @@
 """Abstraction of scientific article data and related tools."""
 from __future__ import annotations
 
+import enum
 import html
 import re
 import string
@@ -31,6 +32,17 @@ from defusedxml import ElementTree
 from mashumaro import DataClassJSONMixin
 
 from bluesearch.database.identifiers import generate_uid
+
+
+class ArticleSource(enum.Enum):
+    """The source of an article."""
+
+    ARXIV = "arxiv"
+    BIORXIV = "biorxiv"
+    MEDRXIV = "medrxiv"
+    PMC = "pmc"
+    PUBMED = "pubmed"
+    UNKNOWN = None
 
 
 def get_arxiv_id(path: str | Path) -> str | None:

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -42,7 +42,7 @@ class ArticleSource(enum.Enum):
     MEDRXIV = "medrxiv"
     PMC = "pmc"
     PUBMED = "pubmed"
-    UNKNOWN = None
+    UNKNOWN = "unknown"
 
 
 def get_arxiv_id(path: str | Path) -> str | None:

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -402,7 +402,7 @@ def extract_article_topics_from_medrxiv_article(
 
     Returns
     -------
-    topic : pathlib.Path or str
+    topic : str
         The subject area of the article.
     journal : str
         The journal the article was published in. Should be either

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -1,0 +1,116 @@
+# Blue Brain Search is a text mining toolbox focused on scientific use cases.
+#
+# Copyright (C) 2020  Blue Brain Project, EPFL.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Implementation of the TopicInfo data structure."""
+from __future__ import annotations
+
+import copy
+import datetime
+import pathlib
+from dataclasses import dataclass, field
+from typing import Any
+
+import bluesearch
+from bluesearch.database.article import ArticleSource
+
+
+@dataclass
+class TopicInfo:
+    """The topic information extracted from a journal article.
+
+    For the spec see the following GitHub issue/comment:
+    https://github.com/BlueBrain/Search/issues/518#issuecomment-985525160
+    """
+
+    source: ArticleSource
+    path: str | pathlib.Path
+    element_in_file: int | None = None
+    article_topics: dict[str, list[str]] = field(init=False, default_factory=dict)
+    journal_topics: dict[str, list[str]] = field(init=False, default_factory=dict)
+    metadata: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Run the post-initialization."""
+        self.creation_date = datetime.datetime.now()
+
+    @staticmethod
+    def add_topics(mapping: dict[str, list[str]], kind: str, topics: list[str]) -> None:
+        """Add topics to a mapping with collection of topics.
+
+        Parameters
+        ----------
+        mapping
+            A mapping of the form kind -> list-of-topics that shall be
+            updated in-place. For example ``{"MeSH": ["topic 1", "topic 2"]}``.
+        kind
+            The topic kind. Corresponds to a key in ``mapping``.
+        topics
+            The topics to add. Corresponds to a value in ``mapping``.
+        """
+        updated_topics = mapping.get(kind, []) + topics
+        mapping[kind] = sorted(set(updated_topics))
+
+    def add_article_topics(self, kind: str, topics: list[str]) -> None:
+        """Add article topics.
+
+        Parameters
+        ----------
+        kind
+            The topic kind. For example "MeSH" or "MAG".
+        topics
+            A list of the topics to add.
+        """
+        self.add_topics(self.article_topics, kind, topics)
+
+    def add_journal_topics(self, kind: str, topics: list[str]) -> None:
+        """Add journal topics.
+
+        Parameters
+        ----------
+        kind
+            The topic kind. For example "MeSH" or "MAG".
+        topics
+            A list of the topics to add.
+        """
+        self.add_topics(self.journal_topics, kind, topics)
+
+    def json(self) -> dict:
+        """Convert the contents of this class to a structured dictionary.
+
+        Returns
+        -------
+        dict
+            The structure dictionary with all topic information.
+        """
+        metadata: dict[str, Any] = {
+            **copy.deepcopy(self.metadata),
+            "created-date": self.creation_date.strftime("%Y-%m-%d %H:%M:%S"),
+            "bbs-version": bluesearch.__version__,
+        }
+        if self.element_in_file is not None:
+            metadata["element_in_file"] = self.element_in_file
+
+        json = {
+            "source": self.source.value,
+            "path": str(self.path),
+            "topics": {
+                "article": copy.deepcopy(self.article_topics),
+                "journal": copy.deepcopy(self.journal_topics),
+            },
+            "metadata": metadata,
+        }
+
+        return json

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -40,7 +40,6 @@ class TopicInfo:
     element_in_file: int | None = None
     article_topics: dict[str, list[str]] = field(init=False, default_factory=dict)
     journal_topics: dict[str, list[str]] = field(init=False, default_factory=dict)
-    metadata: dict = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Run the post-initialization."""
@@ -96,7 +95,6 @@ class TopicInfo:
             The structure dictionary with all topic information.
         """
         metadata: dict[str, Any] = {
-            **copy.deepcopy(self.metadata),
             "created-date": self.creation_date.strftime("%Y-%m-%d %H:%M:%S"),
             "bbs-version": bluesearch.__version__,
         }

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -90,6 +90,10 @@ class TopicInfo:
     def json(self) -> dict:
         """Convert the contents of this class to a structured dictionary.
 
+        Apart from the source, path and topic entries a "metadata" top-level
+        key will be added containing a dictionary with entries "created-date"
+        and "bbs-version".
+
         Returns
         -------
         dict

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -44,6 +44,7 @@ class TopicInfo:
     def __post_init__(self) -> None:
         """Run the post-initialization."""
         self.creation_date = datetime.datetime.now()
+        self.path = pathlib.Path(self.path).resolve()
 
     @staticmethod
     def add_topics(mapping: dict[str, list[str]], kind: str, topics: list[str]) -> None:

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -47,7 +47,7 @@ class TopicInfo:
         self.path = pathlib.Path(self.path).resolve()
 
     @staticmethod
-    def add_topics(mapping: dict[str, list[str]], kind: str, topics: list[str]) -> None:
+    def _add_topics(mapping: dict[str, list[str]], kind: str, topics: list[str]) -> None:
         """Add topics to a mapping with collection of topics.
 
         Parameters
@@ -73,7 +73,7 @@ class TopicInfo:
         topics
             A list of the topics to add.
         """
-        self.add_topics(self.article_topics, kind, topics)
+        self._add_topics(self.article_topics, kind, topics)
 
     def add_journal_topics(self, kind: str, topics: list[str]) -> None:
         """Add journal topics.
@@ -85,7 +85,7 @@ class TopicInfo:
         topics
             A list of the topics to add.
         """
-        self.add_topics(self.journal_topics, kind, topics)
+        self._add_topics(self.journal_topics, kind, topics)
 
     def json(self) -> dict:
         """Convert the contents of this class to a structured dictionary.

--- a/src/bluesearch/database/topic_info.py
+++ b/src/bluesearch/database/topic_info.py
@@ -47,7 +47,9 @@ class TopicInfo:
         self.path = pathlib.Path(self.path).resolve()
 
     @staticmethod
-    def _add_topics(mapping: dict[str, list[str]], kind: str, topics: list[str]) -> None:
+    def _add_topics(
+        mapping: dict[str, list[str]], kind: str, topics: list[str]
+    ) -> None:
         """Add topics to a mapping with collection of topics.
 
         Parameters

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -177,26 +177,11 @@ def run(
                 if journal_topics:
                     topic_info.add_journal_topics("MeSH", journal_topics)
                 all_results.append(topic_info.json())
-    elif source == "arxiv":
-        all_results = [
-            {
-                "source": "arxiv",
-                "path": str(path.resolve()),
-                "topics": {
-                    "article": {
-                        "arXiv": article_topics,
-                    },
-                },
-                "metadata": {
-                    "created-date": datetime.datetime.now().strftime(
-                        "%Y-%m-%d %H:%M:%S"
-                    ),
-                    "bbs-version": bluesearch.version.__version__,
-                },
-            }
-            for path, article_topics in get_topics_for_arxiv_articles(inputs).items()
-        ]
-
+    elif article_source == ArticleSource.ARXIV:
+        for path, article_topics in get_topics_for_arxiv_articles(inputs).items():
+            topic_info = TopicInfo(source=article_source, path=path)
+            topic_info.add_article_topics("arXiv", article_topics)
+            all_results.append(topic_info.json())
     elif source in {"biorxiv", "medrxiv"}:
         for path in inputs:
             logger.info(f"Processing {path}")

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -121,11 +121,8 @@ def run(
     Parameter description and potential defaults are documented inside of the
     `get_parser` function.
     """
-    import datetime
-
     from defusedxml import ElementTree
 
-    import bluesearch
     from bluesearch.database.topic import (
         extract_article_topics_for_pubmed_article,
         extract_article_topics_from_medrxiv_article,

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -152,7 +152,7 @@ def run(
 
     article_source = ArticleSource(source)
     all_results: list[dict[str, Any]] = []
-    if article_source == ArticleSource.PMC:
+    if article_source is ArticleSource.PMC:
         for path in inputs:
             logger.info(f"Processing {path}")
             topic_info = TopicInfo(source=article_source, path=path.resolve())
@@ -160,7 +160,7 @@ def run(
             if journal_topics:
                 topic_info.add_journal_topics("MeSH", journal_topics)
             all_results.append(topic_info.json())
-    elif article_source == ArticleSource.PUBMED:
+    elif article_source is ArticleSource.PUBMED:
         for path in inputs:
             logger.info(f"Processing {path}")
             articles = ElementTree.parse(input_path)
@@ -177,7 +177,7 @@ def run(
                 if journal_topics:
                     topic_info.add_journal_topics("MeSH", journal_topics)
                 all_results.append(topic_info.json())
-    elif article_source == ArticleSource.ARXIV:
+    elif article_source is ArticleSource.ARXIV:
         for path, article_topics in get_topics_for_arxiv_articles(inputs).items():
             topic_info = TopicInfo(source=article_source, path=path)
             topic_info.add_article_topics("arXiv", article_topics)

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -124,12 +124,12 @@ def run(
     """
     from defusedxml import ElementTree
 
-    from bluesearch.database.topic_info import TopicInfo
     from bluesearch.database.topic import (
         extract_article_topics_for_pubmed_article,
         extract_journal_topics_for_pubmed_article,
         get_topics_for_pmc_article,
     )
+    from bluesearch.database.topic_info import TopicInfo
     from bluesearch.utils import JSONL, find_files
 
     try:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -46,7 +46,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument(
         "source",
         type=str,
-        choices=[member.value for member in ArticleSource.__members__.values()],
+        choices=[member.value for member in ArticleSource],
         help="""
         Format of the input.
         If extracting topic of several articles, all articles must have the same format.

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -45,7 +45,6 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
 
     parser.add_argument(
         "source",
-        type=str,
         choices=[member.value for member in ArticleSource],
         help="""
         Format of the input.
@@ -146,13 +145,8 @@ def run(
         print(*inputs, sep="\n")
         return 0
 
-    try:
-        article_source = ArticleSource(source)
-    except ValueError:
-        logger.error("Unknown article source: %s", source)
-        return 1
+    article_source = ArticleSource(source)
     all_results: list[dict[str, Any]] = []
-
     if article_source == ArticleSource.PMC:
         for path in inputs:
             logger.info(f"Processing {path}")

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -154,7 +154,11 @@ def run(
         print(*inputs, sep="\n")
         return 0
 
-    article_source = ArticleSource(source)
+    try:
+        article_source = ArticleSource(source)
+    except ValueError:
+        logger.error("Unknown article source: %s", source)
+        return 1
     all_results: list[dict[str, Any]] = []
 
     if article_source == ArticleSource.PMC:

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -182,29 +182,13 @@ def run(
             topic_info = TopicInfo(source=article_source, path=path)
             topic_info.add_article_topics("arXiv", article_topics)
             all_results.append(topic_info.json())
-    elif source in {"biorxiv", "medrxiv"}:
+    elif article_source in {ArticleSource.BIORXIV, ArticleSource.MEDRXIV}:
         for path in inputs:
             logger.info(f"Processing {path}")
             topic, journal = extract_article_topics_from_medrxiv_article(path)
-            all_results.append(
-                {
-                    "source": journal,
-                    "path": str(path.resolve()),
-                    "topics": {
-                        "article": {
-                            "Subject Area": topic,
-                        },
-                    },
-                    "metadata": {
-                        "created-date": datetime.datetime.now().strftime(
-                            "%Y-%m-%d %H:%M:%S"
-                        ),
-                        "bbs-version": bluesearch.version.__version__,
-                    },
-                }
-            )
-
-        pass
+            topic_info = TopicInfo(source=ArticleSource(journal), path=path)
+            topic_info.add_article_topics("Subject Area", [topic])
+            all_results.append(topic_info.json())
     else:
         logger.error(f"The source type {source!r} is not implemented yet")
         return 1

--- a/src/bluesearch/entrypoint/database/topic_extract.py
+++ b/src/bluesearch/entrypoint/database/topic_extract.py
@@ -22,6 +22,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from bluesearch.database.article import ArticleSource
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,13 +46,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     parser.add_argument(
         "source",
         type=str,
-        choices=(
-            "arxiv",
-            "biorxiv",
-            "medrxiv",
-            "pmc",
-            "pubmed",
-        ),
+        choices=[member.value for member in ArticleSource.__members__.values()],
         help="""
         Format of the input.
         If extracting topic of several articles, all articles must have the same format.
@@ -128,7 +124,6 @@ def run(
     """
     from defusedxml import ElementTree
 
-    from bluesearch.database.article import ArticleSource
     from bluesearch.database.topic_info import TopicInfo
     from bluesearch.database.topic import (
         extract_article_topics_for_pubmed_article,

--- a/tests/unit/database/test_topic_info.py
+++ b/tests/unit/database/test_topic_info.py
@@ -12,12 +12,10 @@ class TestTopicInfo:
     def test_instantiation(self):
         source = ArticleSource.ARXIV
         path = pathlib.Path("/some/path.test")
-        metadata = {"some key": "some value"}
-        topic_info = TopicInfo(source, path, metadata=metadata)
+        topic_info = TopicInfo(source, path)
 
         assert topic_info.source == source
         assert topic_info.path == path
-        assert metadata == metadata
 
     @pytest.mark.parametrize(
         ("mapping", "kind", "topics", "result"),
@@ -51,7 +49,6 @@ class TestTopicInfo:
             source=ArticleSource.PUBMED,
             path=pathlib.Path("/some/path.test"),
             element_in_file=5,
-            metadata={"some key": "some value"},
         )
         topic_info.add_article_topics("MeSH", ["AT 1", "AT 2", "AT 3"])
         topic_info.add_journal_topics("MAP", ["JT 1", "JT 2"])
@@ -70,7 +67,6 @@ class TestTopicInfo:
         }
         assert start <= metadata["created-date"] <= end
         assert metadata["bbs-version"] == bluesearch.__version__
-        assert metadata["some key"] == "some value"
 
     def test_element_in_file(self):
         json = TopicInfo(ArticleSource.UNKNOWN, "").json()

--- a/tests/unit/database/test_topic_info.py
+++ b/tests/unit/database/test_topic_info.py
@@ -17,6 +17,14 @@ class TestTopicInfo:
         assert topic_info.source == source
         assert topic_info.path == path
 
+    def test_relative_path_is_resolved(self):
+        source = ArticleSource.ARXIV
+        path = pathlib.Path("relative/path")
+        topic_info = TopicInfo(source, path)
+
+        assert topic_info.source == source
+        assert topic_info.path == pathlib.Path.cwd() / path
+
     @pytest.mark.parametrize(
         ("mapping", "kind", "topics", "result"),
         (

--- a/tests/unit/database/test_topic_info.py
+++ b/tests/unit/database/test_topic_info.py
@@ -1,0 +1,80 @@
+import datetime
+import pathlib
+
+import pytest
+
+import bluesearch
+from bluesearch.database.article import ArticleSource
+from bluesearch.database.topic_info import TopicInfo
+
+
+class TestTopicInfo:
+    def test_instantiation(self):
+        source = ArticleSource.ARXIV
+        path = pathlib.Path("/some/path.test")
+        metadata = {"some key": "some value"}
+        topic_info = TopicInfo(source, path, metadata=metadata)
+
+        assert topic_info.source == source
+        assert topic_info.path == path
+        assert metadata == metadata
+
+    @pytest.mark.parametrize(
+        ("mapping", "kind", "topics", "result"),
+        (
+            ({}, "MeSH", ["topic 1"], {"MeSH": ["topic 1"]}),
+            (
+                {"MeSH": ["topic 2"]},
+                "MeSH",
+                ["topic 1"],
+                {"MeSH": ["topic 1", "topic 2"]},
+            ),
+            ({"MeSH": ["topic 1"]}, "MeSH", ["topic 1"], {"MeSH": ["topic 1"]}),
+        ),
+    )
+    def test_add_topics(self, mapping, kind, topics, result):
+        TopicInfo.add_topics(mapping, kind, topics)
+        assert mapping == result
+
+    def test_add_article_journal_topics(self):
+        topic_info = TopicInfo(ArticleSource.UNKNOWN, "")
+        topic_info.add_article_topics("MeSH", ["AT 1", "AT 2", "AT 3"])
+        topic_info.add_journal_topics("MAP", ["JT 1", "JT 2"])
+
+        assert topic_info.article_topics == {"MeSH": ["AT 1", "AT 2", "AT 3"]}
+        assert topic_info.journal_topics == {"MAP": ["JT 1", "JT 2"]}
+
+    def test_json(self):
+        start = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        topic_info = TopicInfo(
+            source=ArticleSource.PUBMED,
+            path=pathlib.Path("/some/path.test"),
+            element_in_file=5,
+            metadata={"some key": "some value"},
+        )
+        topic_info.add_article_topics("MeSH", ["AT 1", "AT 2", "AT 3"])
+        topic_info.add_journal_topics("MAP", ["JT 1", "JT 2"])
+
+        end = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+        json = topic_info.json()
+        metadata = json.pop("metadata")
+        assert json == {
+            "source": ArticleSource.PUBMED.value,
+            "path": "/some/path.test",
+            "topics": {
+                "article": {"MeSH": ["AT 1", "AT 2", "AT 3"]},
+                "journal": {"MAP": ["JT 1", "JT 2"]},
+            },
+        }
+        assert start <= metadata["created-date"] <= end
+        assert metadata["bbs-version"] == bluesearch.__version__
+        assert metadata["some key"] == "some value"
+
+    def test_element_in_file(self):
+        json = TopicInfo(ArticleSource.UNKNOWN, "").json()
+        assert json["metadata"].get("element_in_file") is None
+
+        json = TopicInfo(ArticleSource.UNKNOWN, "", element_in_file=5).json()
+        assert json["metadata"].get("element_in_file") == 5

--- a/tests/unit/database/test_topic_info.py
+++ b/tests/unit/database/test_topic_info.py
@@ -39,7 +39,7 @@ class TestTopicInfo:
         ),
     )
     def test_add_topics(self, mapping, kind, topics, result):
-        TopicInfo.add_topics(mapping, kind, topics)
+        TopicInfo._add_topics(mapping, kind, topics)
         assert mapping == result
 
     def test_add_article_journal_topics(self):

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -26,6 +26,7 @@ from unittest.mock import Mock
 import pytest
 from google.cloud.storage import Blob
 
+from bluesearch.database.article import ArticleSource
 from bluesearch.entrypoint.database import download
 
 DOWNLOAD_PARAMS = {"source", "from_month", "output_dir", "dry_run"}
@@ -268,11 +269,11 @@ class TestArxivDownload:
 @pytest.mark.parametrize(
     ("source", "expected_date"),
     [
-        ("arxiv", "April 2007"),
-        ("biorxiv", "December 2018"),
-        ("medrxiv", "October 2020"),
-        ("pmc", "December 2021"),
-        ("pubmed", "December 2021"),
+        (ArticleSource.ARXIV, "April 2007"),
+        (ArticleSource.BIORXIV, "December 2018"),
+        (ArticleSource.MEDRXIV, "October 2020"),
+        (ArticleSource.PMC, "December 2021"),
+        (ArticleSource.PUBMED, "December 2021"),
     ],
 )
 def test_structure_change(source, expected_date, tmp_path, caplog):
@@ -281,7 +282,7 @@ def test_structure_change(source, expected_date, tmp_path, caplog):
     fake_datetime = limit_datetime - datetime.timedelta(days=32)
 
     with caplog.at_level(logging.ERROR):
-        exit_code = download.run(source, fake_datetime, tmp_path, dry_run=False)
+        exit_code = download.run(source.value, fake_datetime, tmp_path, dry_run=False)
 
     assert exit_code == 1
     assert expected_date in caplog.text

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -132,7 +132,6 @@ def test_pmc_source(test_data_path, capsys, monkeypatch, tmp_path):
     assert result["path"] == str(pmc_path)
     assert isinstance(result["topics"], dict)
     topics = result["topics"]
-    assert "article" not in topics
     assert "journal" in topics
     assert isinstance(topics["journal"], dict)
     assert topics["journal"]["MeSH"] == meshes

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -84,7 +84,7 @@ def test_wrong_source(test_data_path, caplog, tmp_path):
             dry_run=False,
         )
     assert exit_code == 1
-    assert "The source type" in caplog.text
+    assert "Unknown article source" in caplog.text
 
 
 def test_dry_run(test_data_path, capsys, tmp_path):

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -71,11 +71,11 @@ def test_input_path_not_correct(caplog):
     assert "Argument 'input_path'" in caplog.text
 
 
-def test_wrong_source(test_data_path, caplog, tmp_path):
+def test_source_type_not_implemented(test_data_path, caplog, tmp_path):
     pmc_path = test_data_path / "jats_article.xml"
     with caplog.at_level(logging.ERROR):
         exit_code = topic_extract.run(
-            source="wrong_type",
+            source="unknown",
             input_path=pmc_path,
             output_file=tmp_path,
             match_filename=None,
@@ -84,7 +84,7 @@ def test_wrong_source(test_data_path, caplog, tmp_path):
             dry_run=False,
         )
     assert exit_code == 1
-    assert "Unknown article source" in caplog.text
+    assert "not implemented" in caplog.text
 
 
 def test_dry_run(test_data_path, capsys, tmp_path):

--- a/tests/unit/entrypoint/database/test_topic_extract.py
+++ b/tests/unit/entrypoint/database/test_topic_extract.py
@@ -176,7 +176,7 @@ def test_medbiorxiv_source(capsys, monkeypatch, tmp_path, source):
 
     # Mocking
     fake_extract_article_topics_from_medrxiv_article = Mock(
-        side_effect=lambda p: ("TOPIC", "JOURNAL")
+        side_effect=lambda p: ("TOPIC", source)
     )
 
     monkeypatch.setattr(
@@ -200,8 +200,8 @@ def test_medbiorxiv_source(capsys, monkeypatch, tmp_path, source):
     result = JSONL.load_jsonl(output_file)
     assert len(result) == 1
 
-    assert result[0]["source"] == "JOURNAL"
-    assert result[0]["topics"]["article"]["Subject Area"] == "TOPIC"
+    assert result[0]["source"] == source
+    assert result[0]["topics"]["article"]["Subject Area"] == ["TOPIC"]
 
 
 def test_pubmed_source(test_data_path, capsys, monkeypatch, tmp_path):


### PR DESCRIPTION
Fixes #539 .

## Description
This adds the `TopicInfo` data class that replaces the manual creation and copy-pasting of the structured dictionary that we have been using for this purpose so far.

## How to test?
* See new tests under `tests/unit/database/test_topic_info.py`
* Adjusted tests for old code pass

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
