### PR TITLE
Fix responses=0.17.0 deprecation issue

### DIFF
--- a/tests/unit/widgets/test_mining_widget.py
+++ b/tests/unit/widgets/test_mining_widget.py
@@ -148,6 +148,7 @@ def test_mining_text(monkeypatch, capsys, mining_schema_df):
         "http://test/text",
         callback=request_callback,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     responses.add_callback(
@@ -155,6 +156,7 @@ def test_mining_text(monkeypatch, capsys, mining_schema_df):
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     mining_schema = MiningSchema()
@@ -188,6 +190,7 @@ def test_mining_database(monkeypatch, capsys, fake_sqlalchemy_engine, mining_sch
         "http://test/database",
         callback=request_callback,
         content_type="text/csv",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     responses.add_callback(
@@ -195,6 +198,7 @@ def test_mining_database(monkeypatch, capsys, fake_sqlalchemy_engine, mining_sch
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     mining_schema = MiningSchema()
@@ -249,6 +253,7 @@ def test_save_load_checkpoint(monkeypatch, capsys, mining_schema_df, tmpdir):
         "http://test/text",
         callback=request_callback,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     responses.add_callback(
@@ -256,6 +261,7 @@ def test_save_load_checkpoint(monkeypatch, capsys, mining_schema_df, tmpdir):
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     mining_schema = MiningSchema()

--- a/tests/unit/widgets/test_search_widget.py
+++ b/tests/unit/widgets/test_search_widget.py
@@ -178,6 +178,7 @@ def activate_responses(fake_sqlalchemy_engine):
         http_address,
         callback=partial(request_callback, searcher=searcher),
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
     return http_address
 
@@ -222,6 +223,7 @@ def test_paging(
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     widget = SearchWidget(
@@ -307,6 +309,7 @@ def test_correct_results_order(fake_sqlalchemy_engine, monkeypatch, capsys):
         "http://test",
         callback=partial(request_callback, searcher=searcher),
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     responses.add_callback(
@@ -314,6 +317,7 @@ def test_correct_results_order(fake_sqlalchemy_engine, monkeypatch, capsys):
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     k = 1
@@ -353,6 +357,7 @@ def test_article_saver_gets_updated(
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     k = 10
@@ -424,6 +429,7 @@ def test_article_saver_global(fake_sqlalchemy_engine, monkeypatch, capsys, savin
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     k = 10
@@ -486,6 +492,7 @@ def test_inclusion_text(fake_sqlalchemy_engine, monkeypatch, capsys, tmpdir):
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     widget = SearchWidget(
@@ -519,6 +526,7 @@ def test_make_report(fake_sqlalchemy_engine, monkeypatch, capsys, tmpdir):
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     widget = SearchWidget(
@@ -553,6 +561,7 @@ def test_report_article_saver(fake_sqlalchemy_engine, monkeypatch, capsys, tmpdi
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     widget = SearchWidget(
@@ -587,6 +596,7 @@ def get_search_widget_bot(
         "http://test/help",
         callback=request_callback_help,
         content_type="application/json",
+        match_querystring=None,  # https://github.com/getsentry/responses/issues/464
     )
 
     widget = SearchWidget(


### PR DESCRIPTION
Fixes #543.

## Description
It is due to a bug in `responses=1.17.0`. One can manually provide `match_stringquery=None` in order to avoid deprecation warnings.
