### PR TITLE
Fix `DeprecationWarning` for `df.append`

### DIFF
--- a/src/bluesearch/mining/entity.py
+++ b/src/bluesearch/mining/entity.py
@@ -167,7 +167,9 @@ class PatternCreator:
 
         new_row = self.raw2row({"label": label, "pattern": pattern_})
 
-        new_storage = self._storage.append(new_row.to_frame().T, ignore_index=True)
+        new_storage = pd.concat(
+            [self._storage, new_row.to_frame().T], ignore_index=True
+        )
         if check_exists and new_storage.duplicated().any():
             raise ValueError("The pattern already exists")
 

--- a/src/bluesearch/server/mining_server.py
+++ b/src/bluesearch/server/mining_server.py
@@ -198,13 +198,13 @@ class MiningServer(Flask):
                         paragraph = retrieve_paragraph(
                             article_id, paragraph_pos, engine=self.connection
                         )
-                        all_paragraphs = all_paragraphs.append(paragraph)
+                        all_paragraphs = pd.concat([all_paragraphs, paragraph])
 
                 if all_article_ids:
                     articles = retrieve_articles(
                         article_ids=all_article_ids, engine=self.connection
                     )
-                    all_paragraphs = all_paragraphs.append(articles)
+                    all_paragraphs = pd.concat([all_paragraphs, articles])
 
                 texts = [
                     (
@@ -277,7 +277,7 @@ class MiningServer(Flask):
             df = run_pipeline(
                 texts=texts, model_entities=ee_model, models_relations={}, debug=debug
             )
-            df_all = df_all.append(df)
+            df_all = pd.concat([df_all, df])
 
         df_all = self.add_ontology_column(df_all, schema_df)
         self.logger.info(f"Mining completed. Mined {len(df_all)} items.")

--- a/src/bluesearch/sql.py
+++ b/src/bluesearch/sql.py
@@ -379,7 +379,7 @@ def retrieve_mining_cache(identifiers, etypes, engine):
         logger.debug("setting df_pars to emtpy because `not identifiers_pars == True`")
         df_pars = pd.DataFrame()
 
-    return df_pars.append(df_arts, ignore_index=True)
+    return pd.concat([df_pars, df_arts], ignore_index=True)
 
 
 class SentenceFilter:

--- a/src/bluesearch/widgets/article_saver.py
+++ b/src/bluesearch/widgets/article_saver.py
@@ -205,13 +205,13 @@ class ArticleSaver:
         full_articles, just_paragraphs = self._get_clean_state()
 
         articles = retrieve_articles(article_ids=full_articles, engine=self.connection)
-        self.df_chosen_texts = self.df_chosen_texts.append(articles)
+        self.df_chosen_texts = pd.concat([self.df_chosen_texts, articles])
 
         for (article_id, paragraph_pos_in_article) in just_paragraphs:
             paragraph = retrieve_paragraph(
                 article_id, paragraph_pos_in_article, engine=self.connection
             )
-            self.df_chosen_texts = self.df_chosen_texts.append(paragraph)
+            self.df_chosen_texts = pd.concat([self.df_chosen_texts, paragraph])
 
     def get_chosen_texts(self):
         """Retrieve the currently saved items.

--- a/src/bluesearch/widgets/mining_schema.py
+++ b/src/bluesearch/widgets/mining_schema.py
@@ -60,17 +60,20 @@ class MiningSchema:
         ontology_source : str, optional
             The ontology source, for example "NCIT".
         """
-        row = {
-            "entity_type": entity_type,
-            "property": property_name,
-            "property_type": property_type,
-            "property_value_type": property_value_type,
-            "ontology_source": ontology_source,
-        }
+        row = pd.DataFrame(
+            [
+                {
+                    "entity_type": entity_type,
+                    "property": property_name,
+                    "property_type": property_type,
+                    "property_value_type": property_value_type,
+                    "ontology_source": ontology_source,
+                }
+            ]
+        )
         # Make sure there are no duplicates to begin with
         self.schema_df = self.schema_df.drop_duplicates(ignore_index=True)
-        # 'row' has type dict[str, Any]. It is valid for append(). Ignoring the error.
-        self.schema_df = self.schema_df.append(row, ignore_index=True)  # type: ignore[arg-type]  # noqa
+        self.schema_df = pd.concat([self.schema_df, row], ignore_index=True)
         # If there are any duplicates at this point, then it must have
         # come from the appended row.
         if any(self.schema_df.duplicated()):


### PR DESCRIPTION
Fixes #555.

## Description

Replace `df.append` by `pd.concat` as suggested by the `DeprecationWarning` message.

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 