### PR TITLE
Tox: move mypy into a separate env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-env: [lint, docs, check-apidoc, check-packaging]
+        tox-env: [lint, type, docs, check-apidoc, check-packaging]
     steps:
       - name: Cancel previous workflows that are still running
         uses: styfle/cancel-workflow-action@0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,17 @@ deps =
     flake8-comprehensions==3.5.0
     flake8-docstrings==1.6.0
     isort==5.9.1
+commands =
+    flake8 {posargs:{[tox]sources}}
+    isort --check {posargs:{[tox]sources}}
+    black --check {posargs:{[tox]sources}}
+    bandit -qr --exclude "benchmarks/,tests/,data_and_models/pipelines/ner/transformers_vs_spacy/transformers/" \
+    {posargs:{[tox]sources}}
+
+[testenv:type]
+basepython = python3.7
+skip_install = true
+deps =
     mypy==0.910
     pandas-stubs==1.2.0.1
     sqlalchemy-stubs==0.4
@@ -51,11 +62,6 @@ deps =
     types-setuptools==57.0.0
     typing-extensions==3.10.0.0
 commands =
-    flake8 {posargs:{[tox]sources}}
-    isort --check {posargs:{[tox]sources}}
-    black --check {posargs:{[tox]sources}}
-    bandit -qr --exclude "benchmarks/,tests/,data_and_models/pipelines/ner/transformers_vs_spacy/transformers/" \
-    {posargs:{[tox]sources}}
     mypy {posargs:{[tox]sources}}
 
 [testenv:format]

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,12 @@
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
 sources = setup.py src/bluesearch tests benchmarks data_and_models
-envlist = lint, py{37, 38, 39}, docs, check-apidoc check-packaging
+envlist = lint, type, py{37, 38, 39}, docs, check-apidoc, check-packaging
 ; Enable PEP-517/518, https://tox.wiki/en/latest/config.html#conf-isolated_build
 isolated_build = true
 
 [testenv]
+description = Run pytest
 download = true
 deps =
     en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.0.0/en_core_web_sm-3.0.0.tar.gz
@@ -33,6 +34,7 @@ allowlist_externals = docker
 commands = pytest -m "" {posargs:tests}
 
 [testenv:lint]
+description = Lint using flake8, black, isort and bandit
 basepython = python3.7
 skip_install = true
 deps =
@@ -51,6 +53,7 @@ commands =
     {posargs:{[tox]sources}}
 
 [testenv:type]
+description = Run static type checks using mypy
 basepython = python3.7
 skip_install = true
 deps =
@@ -65,6 +68,7 @@ commands =
     mypy {posargs:{[tox]sources}}
 
 [testenv:format]
+description = Apply black and isort
 basepython = python3.7
 skip_install = true
 deps =
@@ -75,35 +79,37 @@ commands =
     black {posargs:{[tox]sources}}
 
 [testenv:docs]
+description = Build docs and run doctest
 basepython = python3.7
 changedir = docs
 extras = dev
+allowlist_externals = make
 # set warnings as errors using the -W sphinx option
 commands =
     make clean
     make doctest SPHINXOPTS=-W
     make html SPHINXOPTS=-W
-allowlist_externals = make
 
 [testenv:apidoc]
+description = Re-generate the API docs
 skip_install = true
 allowlist_externals = rm
-deps =
-    sphinx
+deps = sphinx
 commands =
     rm -r docs/source/api
     sphinx-apidoc -Tefo docs/source/api src/bluesearch src/bluesearch/version.py
 
 [testenv:check-apidoc]
+description = Check that the API docs are up-to-date
 skip_install = true
 allowlist_externals = diff
-deps =
-    sphinx
+deps = sphinx
 commands =
     sphinx-apidoc -Tefo {envtmpdir} src/bluesearch src/bluesearch/version.py
     diff {envtmpdir} docs/source/api
 
 [testenv:check-packaging]
+description = Generate source and wheel dists and run twine checks
 basepython = python3.7
 deps =
     setuptools-scm
@@ -114,6 +120,7 @@ commands =
     twine check {envtmpdir}/dist/*
 
 [testenv:benchmarks]
+description = Run pytest benchmark tests
 download = true
 extras = dev
 deps = pygal


### PR DESCRIPTION
Fixes #560 .

## Description
Created a new env called "type" that runs static type checks via mypy. Also updated the CI workflow.

Also did small cleaning up of other envs, added env descriptions.

## How to test?
Run the new env using
```sh
tox -e type
```

The old "lint" env should not run mypy any more:
```sh
tox -e lint
```

To see the new env descriptions run
```sh
tox -va
```
## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
