### PR TITLE
Connecting `topic-filter` and `parse`

### DIFF
--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -172,7 +172,7 @@ def run(
             raise ValueError("No input files provided")
         else:
             # Piped session
-            input_lines = sys.stdin.read().splitlines()
+            input_lines = sys.stdin.read().split()
             inputs = []
 
             for line in input_lines:

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -153,7 +153,7 @@ def iter_parsers(input_type: str, input_path: Path) -> Iterator[ArticleParser]:
 def run(
     *,
     input_type: str,
-    input_path: Path or None,
+    input_path: Path | None,
     output_dir: Path,
     match_filename: str | None,
     recursive: bool,

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -79,8 +79,8 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="""
         Path to a file or directory. If a directory, all articles
         inside the directory will be parsed. If not provided the
-        user is supposed to pipe a list of article paths to the standard
-        input.
+        user is supposed to pipe a space separated list of article paths to
+        the standard input.
         """,
         nargs="?",
     )

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -169,7 +169,8 @@ def run(
     if input_path is None:
         if sys.stdin.isatty():
             # Real terminal session
-            raise ValueError("No input files provided")
+            logger.error("No input files provided")
+            return 1
         else:
             # Piped session
             input_lines = sys.stdin.read().split()

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import warnings
 import sys
+import warnings
 from pathlib import Path
 from typing import Iterator
 

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -175,12 +175,6 @@ def test_dry_run(capsys):
     assert captured.out == "tests/data/cord19_v35/metadata.csv\n"
 
 class TestPipe:
-    def test_nothing_provided(self, monkeypatch):
-        """Both input_file and standard input are empty."""
-
-        with pytest.raises(ValueError, match="No input files provided"):
-            main(["parse", "cord19-json", "some_output_folder"])
-
     def test_piped_session(self, tmp_path):
         """Both input_file and standard input are empty."""
 

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -181,11 +181,12 @@ class TestPipe:
 
         file_a = tmp_path / "a.xml"
         file_b = tmp_path / "b.xml"
+        file_c = tmp_path / "c.xml"  # it is not going to exist
 
         file_a.touch()
         file_b.touch()
 
-        stdin = f"{file_a.resolve()} {file_b.resolve()}"
+        stdin = f"{file_a.resolve()} {file_b.resolve()} {file_c.resolve()}"
 
         res = subprocess.run(
             ["bbs_database", "parse", "-n", "cord19-json", "whatever"],

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -202,5 +202,4 @@ class TestPipe:
         assert res.returncode == 0
 
         stdout_expected = str.encode(f"{file_a.resolve()}\n{file_b.resolve()}\n")
-        assert res.stdout == stdout_expected 
-
+        assert res.stdout == stdout_expected

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -190,16 +190,18 @@ class TestPipe:
         file_a.touch()
         file_b.touch()
 
-        stdin = str.encode(f"{file_a.resolve()} {file_b.resolve()}")
+        stdin = f"{file_a.resolve()} {file_b.resolve()}"
 
         res = subprocess.run(
             ["bbs_database", "parse", "-n", "cord19-json", "whatever"],
             input=stdin,
             check=True,
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            capture_output=True,
+            text=True,
         )
 
         assert res.returncode == 0
 
-        stdout_expected = str.encode(f"{file_a.resolve()}\n{file_b.resolve()}\n")
+        stdout_expected = f"{file_a.resolve()}\n{file_b.resolve()}\n"
+
         assert res.stdout == stdout_expected

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -174,6 +174,7 @@ def test_dry_run(capsys):
     captured = capsys.readouterr()
     assert captured.out == "tests/data/cord19_v35/metadata.csv\n"
 
+
 class TestPipe:
     def test_piped_session(self, tmp_path):
         """Both input_file and standard input are empty."""

--- a/tests/unit/entrypoint/database/test_parse.py
+++ b/tests/unit/entrypoint/database/test_parse.py
@@ -177,7 +177,7 @@ def test_dry_run(capsys):
 
 class TestPipe:
     def test_piped_session(self, tmp_path):
-        """Both input_file and standard input are empty."""
+        """The input_file is not provided by stdin contains filenames."""
 
         file_a = tmp_path / "a.xml"
         file_b = tmp_path / "b.xml"


### PR DESCRIPTION
Fixes #559 

## Description
* The `bbs_database parse` was adjusted to also support ingesting of piped standard input
  - Before:
  ```bash
  bbs_database parse parser input_path output_dir
  ```
  - After:
   ```bash
  bbs_database parse parser input_path output_dir # still possible
  echo "file_1.py file_2.py" | bbs_database parse parser output_dir # this one works too
  ```
* A shell script (see below an example) can take care of the creation of the string to be piped. Built from `awk` and `clip`.

## How to test?
First of all, create a bunch of empty files

```bash
touch 0.xml a.xml b.xml c.xml d.xml e.xml f.xml g.xml h.xml
```

Then create the following `output.csv`

```bash
path,element_in_file,accept,source                                                                                                                                                                                                                                              
0.xml,,True,arxiv                                                                                                                                                                                                                                                               
a.xml,,False,biorxiv                                                                                                                                                                                                                                                             
b.xml,,True,biorxiv                                                                                                                                                                                                                                                             
c.xml,,True,medrxiv                                                                                                                                                                                                                                                             
d.xml,,False,medrxiv                                                                                                                                                                                                                                                            
e.xml,387.0,True,pubmed                                                                                                                                                                                                                                                         
f.xml,387.0,True,pubmed                                                                                                                                                                                                                                                         
g.xml,387.0,True,pmc                                                                                                                                                                                                                                                            
h.xml,387.0,False,pmc   
```
Then you can run the following script. Note that it does both the grouping based on the `source` and also only takes the articles that were "accepted" in the `topic-filter` stage.


```bash
SOURCES=("arxiv" "biorxiv" "medrxiv" "pubmed" "pmc")                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                
OUTPUT=output.csv                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                
for SOURCE in "${SOURCES[@]}"; do                                                                                                                                                                                                                                               
    PARSER='cord19-json'  # to be adjusted                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                
    echo source=$SOURCE                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                
    pipe=$(awk -F , '$3 == "True"  && $4 == '\"$SOURCE\"' { print }' $OUTPUT | cut -d ',' -f1)                                                                                                                                                                                  
    echo $pipe | bbs_database parse -n $PARSER final_output_folder                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                
    echo "-------------"                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
done                                                                                                                                                                                                                                               
```
It should give you the following 
```
source=arxiv
0.xml
-------------
source=biorxiv
b.xml
-------------
source=medrxiv
c.xml
-------------
source=pubmed
e.xml
f.xml
-------------
source=pmc
g.xml
-------------
```

## Issues / to discuss
* When we use the `bbs_database parse` in the pipe mode `pdb` does not seem to work
* `pytest` sets stdin to null and `sys.stdin.isatty() == False` which makes the testing more tricky. This PR spawns subprocesses to avoid problems. Unfortunately, these tests are not going to count towards the coverage.
## Checklist

- [ ] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [ ] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] Type annotations added.
  (if a function is added or modified)
- [ ] All CI tests pass. 
