### PR TITLE
Restrict logging level manipulation to `bluesearch` loggers

### DIFF
--- a/src/bluesearch/entrypoint/database/parent.py
+++ b/src/bluesearch/entrypoint/database/parent.py
@@ -21,10 +21,10 @@ Cmd = namedtuple("Cmd", ["help", "init_parser", "run"])
 
 
 def _setup_logging(logging_level: int) -> None:
-    root_logger = logging.getLogger()
+    bluesearch_logger = logging.getLogger("bluesearch")
 
     # Logging level
-    root_logger.setLevel(logging_level)
+    bluesearch_logger.setLevel(logging_level)
 
     # Formatter
     fmt = "%(asctime)s - %(levelname)s - %(name)s - %(message)s"
@@ -33,7 +33,7 @@ def _setup_logging(logging_level: int) -> None:
     # Handler
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
-    root_logger.addHandler(handler)
+    bluesearch_logger.addHandler(handler)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -12,7 +12,7 @@ def test_commands_work(command):
 
 
 def test_setup_logging(caplog):
-    caplog.set_level(logging.WARNING)  # set root logger level to WARNING
+    caplog.set_level(logging.WARNING, logger="bluesearch")
 
     all_loggers = logging.root.manager.loggerDict
     bluesearch_loggers = {
@@ -42,6 +42,7 @@ def test_setup_logging(caplog):
         name: logger.getEffectiveLevel() for name, logger in external_loggers.items()
     }
 
-    assert bluesearch_levels_before != bluesearch_levels_after
+    assert set(bluesearch_levels_before.values()) == {logging.WARNING}
     assert set(bluesearch_levels_after.values()) == {logging.DEBUG}
+
     assert external_levels_before == external_levels_after

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -1,8 +1,50 @@
+import logging
 import subprocess
 
 import pytest
+
+from bluesearch.entrypoint.database.parent import _setup_logging
 
 
 @pytest.mark.parametrize("command", ["add", "convert-pdf", "init", "parse"])
 def test_commands_work(command):
     subprocess.run(["bbs_database", command, "--help"], check=True)
+
+
+def test_setup_logging():
+    """This test modifies logging levels globally.
+
+    However, it should not be a big deal since each CLI entrypoint ends up
+    calling `_setup_logging`.
+    """
+    all_loggers = logging.root.manager.loggerDict
+    bluesearch_loggers = {
+        k: v
+        for k, v in all_loggers.items()
+        if k.startswith("bluesearch") and isinstance(v, logging.Logger)
+    }
+    external_loggers = {
+        k: v
+        for k, v in all_loggers.items()
+        if not k.startswith("bluesearch") and isinstance(v, logging.Logger)
+    }
+
+    bluesearch_levels_before = {
+        name: logger.getEffectiveLevel() for name, logger in bluesearch_loggers.items()
+    }
+    external_levels_before = {
+        name: logger.getEffectiveLevel() for name, logger in external_loggers.items()
+    }
+
+    _setup_logging(logging.DEBUG)
+
+    bluesearch_levels_after = {
+        name: logger.getEffectiveLevel() for name, logger in bluesearch_loggers.items()
+    }
+    external_levels_after = {
+        name: logger.getEffectiveLevel() for name, logger in external_loggers.items()
+    }
+
+    assert bluesearch_levels_before != bluesearch_levels_after
+    assert set(bluesearch_levels_after.values()) == {logging.DEBUG}
+    assert external_levels_before == external_levels_after

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import subprocess
 
@@ -12,6 +14,10 @@ def test_commands_work(command):
 
 
 def test_setup_logging(caplog):
+    def get_levels(loggers: dict[str, logging.Logger]) -> dict[str, int]:
+        """Get logging level for each logger."""
+        return {name: logger.getEffectiveLevel() for name, logger in loggers.items()}
+
     caplog.set_level(logging.WARNING, logger="bluesearch")
 
     all_loggers = logging.root.manager.loggerDict
@@ -26,21 +32,13 @@ def test_setup_logging(caplog):
         if not k.startswith("bluesearch") and isinstance(v, logging.Logger)
     }
 
-    bluesearch_levels_before = {
-        name: logger.getEffectiveLevel() for name, logger in bluesearch_loggers.items()
-    }
-    external_levels_before = {
-        name: logger.getEffectiveLevel() for name, logger in external_loggers.items()
-    }
+    bluesearch_levels_before = get_levels(bluesearch_loggers)
+    external_levels_before = get_levels(external_loggers)
 
     _setup_logging(logging.DEBUG)
 
-    bluesearch_levels_after = {
-        name: logger.getEffectiveLevel() for name, logger in bluesearch_loggers.items()
-    }
-    external_levels_after = {
-        name: logger.getEffectiveLevel() for name, logger in external_loggers.items()
-    }
+    bluesearch_levels_after = get_levels(bluesearch_loggers)
+    external_levels_after = get_levels(external_loggers)
 
     assert set(bluesearch_levels_before.values()) == {logging.WARNING}
     assert set(bluesearch_levels_after.values()) == {logging.DEBUG}

--- a/tests/unit/entrypoint/database/test_parent.py
+++ b/tests/unit/entrypoint/database/test_parent.py
@@ -11,12 +11,9 @@ def test_commands_work(command):
     subprocess.run(["bbs_database", command, "--help"], check=True)
 
 
-def test_setup_logging():
-    """This test modifies logging levels globally.
+def test_setup_logging(caplog):
+    caplog.set_level(logging.WARNING)  # set root logger level to WARNING
 
-    However, it should not be a big deal since each CLI entrypoint ends up
-    calling `_setup_logging`.
-    """
     all_loggers = logging.root.manager.loggerDict
     bluesearch_loggers = {
         k: v


### PR DESCRIPTION
Fixes #565 