### PR TITLE
Inconsistency: `parse` assumes unzipped `JATS XML` but topic-extract assumes zipped `.meca`

### DIFF
--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,6 +29,7 @@ Legend
 
 Latest
 ======
+- |Add| :code:`MecaParser` to parse BiorXiv and MedrXiv articles in .meca format.
 - |Change| the UID of an article is computed by hashing the identifiers if those
   exist, otherwise by hashing the article contents.
 - |Add| entrypoint :code:`bbs_database topic-filter`.

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -29,7 +29,8 @@ Legend
 
 Latest
 ======
-- |Add| :code:`MecaParser` to parse BiorXiv and MedrXiv articles in .meca format.
+- |Add| possibility to read `.xml` and `.meca` file extensions in :code:`JATSXMLParser`
+to parse BiorXiv and MedrXiv articles
 - |Add| the ``--mesh-topic-db`` option to ``bbs_database topic-extract``
 - |Add| the ``bbs_database parse-mesh-rdf`` command
 - |Add| the ``bluesearch.database.mesh`` module

--- a/docs/source/whatsnew.rst
+++ b/docs/source/whatsnew.rst
@@ -30,7 +30,7 @@ Legend
 Latest
 ======
 - |Add| possibility to read `.xml` and `.meca` file extensions in :code:`JATSXMLParser`
-to parse BiorXiv and MedrXiv articles
+  to parse BiorXiv and MedrXiv articles
 - |Add| the ``--mesh-topic-db`` option to ``bbs_database topic-extract``
 - |Add| the ``bbs_database parse-mesh-rdf`` command
 - |Add| the ``bluesearch.database.mesh`` module

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -309,7 +309,7 @@ class JATSXMLParser(ArticleParser):
 
     @classmethod
     def from_zip(cls, path: str | Path) -> JATSXMLParser:
-        """Read xml file and instantiate JATSXML Parser.
+        """Read xml file from a zipped .meca folder and instantiate JATSXML Parser.
 
         Parameters
         ----------

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -24,12 +24,12 @@ import logging
 import re
 import string
 import unicodedata
-import zipfile
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Generator, Iterable, Optional, Sequence, Tuple
 from xml.etree.ElementTree import Element  # nosec
+from zipfile import ZipFile
 
 from defusedxml import ElementTree
 from mashumaro import DataClassJSONMixin
@@ -534,7 +534,7 @@ class MecaParser(JATSXMLParser):
 
     def __init__(self, path: str | Path) -> None:
 
-        with zipfile.ZipFile(path) as myzip:
+        with ZipFile(path) as myzip:
             xml_files = [
                 x
                 for x in myzip.namelist()

--- a/src/bluesearch/database/article.py
+++ b/src/bluesearch/database/article.py
@@ -262,8 +262,8 @@ class JATSXMLParser(ArticleParser):
 
     Parameters
     ----------
-    path
-        The path to a JATS XML file.
+    xml_stream
+        The xml stream of the article.
     """
 
     def __init__(self, xml_stream: IO) -> None:

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -276,7 +276,11 @@ def get_topics_for_pmc_article(
         Journal topics for the given article.
     """
     # Determine journal title
-    parser = JATSXMLParser(pmc_path)
+    if str(pmc_path).endswith(".xml"):
+        parser = JATSXMLParser.from_xml(pmc_path)
+    else:
+        parser = JATSXMLParser.from_zip(pmc_path)
+
     nlm_ta = parser.content.find(
         "./front/journal-meta/journal-id[@journal-id-type='nlm-ta']"
     )

--- a/src/bluesearch/database/topic.py
+++ b/src/bluesearch/database/topic.py
@@ -276,10 +276,16 @@ def get_topics_for_pmc_article(
         Journal topics for the given article.
     """
     # Determine journal title
-    if str(pmc_path).endswith(".xml"):
+    *_, extension = str(pmc_path).lower().rpartition(".")
+    if extension == "xml":
         parser = JATSXMLParser.from_xml(pmc_path)
-    else:
+    elif extension == "meca" or extension == "zip":
         parser = JATSXMLParser.from_zip(pmc_path)
+    else:
+        raise ValueError(
+            f"Unknown file extension for JATS XML: {extension!r}. Only XML and ZIP "
+            f"are supported. File: {str(pmc_path)!r}"
+        )
 
     nlm_ta = parser.content.find(
         "./front/journal-meta/journal-id[@journal-id-type='nlm-ta']"

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -31,6 +31,7 @@ from bluesearch.database.article import (
     ArticleParser,
     CORD19ArticleParser,
     JATSXMLParser,
+    MecaParser,
     PubMedXMLParser,
     TEIXMLParser,
 )
@@ -60,6 +61,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         choices=(
             "cord19-json",
             "jats-xml",
+            "meca-xml",
             "pubmed-xml",
             "pubmed-xml-set",
             "tei-xml",
@@ -68,7 +70,8 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         help="""
         Format of the input.
         If parsing several articles, all articles must have the same format.
-        'jats-xml' could be used for articles from PubMed Central, bioRxiv, and medRxiv.
+        'jats-xml' could be used for articles from PubMed Central.
+        'meca-xml' could be used for articles from bioRxiv and medRxiv.
         'tei-xml-arxiv' should be used for TEI XML generated from arXiv PDF articles.
         """,
     )
@@ -126,6 +129,9 @@ def iter_parsers(input_type: str, input_path: Path) -> Iterator[ArticleParser]:
 
     elif input_type == "jats-xml":
         yield JATSXMLParser(input_path)
+
+    elif input_type == "meca-xml":
+        yield MecaParser(input_path)
 
     elif input_type == "pubmed-xml":
         yield PubMedXMLParser(input_path)

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -32,7 +32,6 @@ from bluesearch.database.article import (
     ArticleParser,
     CORD19ArticleParser,
     JATSXMLParser,
-    MecaParser,
     PubMedXMLParser,
     TEIXMLParser,
 )
@@ -132,10 +131,10 @@ def iter_parsers(input_type: str, input_path: Path) -> Iterator[ArticleParser]:
             yield CORD19ArticleParser(data)
 
     elif input_type == "jats-xml":
-        yield JATSXMLParser(input_path)
+        yield JATSXMLParser.from_xml(input_path)
 
-    elif input_type == "meca":
-        yield MecaParser(input_path)
+    elif input_type == "jats-meca":
+        yield JATSXMLParser.from_zip(input_path)
 
     elif input_type == "pubmed-xml":
         yield PubMedXMLParser(input_path)

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -61,7 +61,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         choices=(
             "cord19-json",
             "jats-xml",
-            "meca",
+            "jats-meca",
             "pubmed-xml",
             "pubmed-xml-set",
             "tei-xml",
@@ -71,7 +71,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         Format of the input.
         If parsing several articles, all articles must have the same format.
         'jats-xml' could be used for articles from PubMed Central.
-        'meca' could be used for articles from bioRxiv and medRxiv.
+        'jats-meca' could be used for articles from bioRxiv and medRxiv.
         'tei-xml-arxiv' should be used for TEI XML generated from arXiv PDF articles.
         """,
     )

--- a/src/bluesearch/entrypoint/database/parse.py
+++ b/src/bluesearch/entrypoint/database/parse.py
@@ -61,7 +61,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         choices=(
             "cord19-json",
             "jats-xml",
-            "meca-xml",
+            "meca",
             "pubmed-xml",
             "pubmed-xml-set",
             "tei-xml",
@@ -71,7 +71,7 @@ def init_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         Format of the input.
         If parsing several articles, all articles must have the same format.
         'jats-xml' could be used for articles from PubMed Central.
-        'meca-xml' could be used for articles from bioRxiv and medRxiv.
+        'meca' could be used for articles from bioRxiv and medRxiv.
         'tei-xml-arxiv' should be used for TEI XML generated from arXiv PDF articles.
         """,
     )
@@ -130,7 +130,7 @@ def iter_parsers(input_type: str, input_path: Path) -> Iterator[ArticleParser]:
     elif input_type == "jats-xml":
         yield JATSXMLParser(input_path)
 
-    elif input_type == "meca-xml":
+    elif input_type == "meca":
         yield MecaParser(input_path)
 
     elif input_type == "pubmed-xml":

--- a/tests/unit/database/test_article.py
+++ b/tests/unit/database/test_article.py
@@ -32,7 +32,6 @@ from bluesearch.database.article import (
     ArticleParser,
     CORD19ArticleParser,
     JATSXMLParser,
-    MecaParser,
     PubMedXMLParser,
     TEIXMLParser,
     get_arxiv_id,
@@ -118,17 +117,17 @@ class SimpleTestParser(ArticleParser):
 @pytest.fixture(scope="session")
 def jats_xml_parser(test_data_path):
     path = pathlib.Path(test_data_path) / "jats_article.xml"
-    parser = JATSXMLParser(path.resolve())
+    parser = JATSXMLParser.from_xml(path.resolve())
     return parser
 
 
 @pytest.fixture
-def meca_parser(test_data_path, tmp_path):
+def jats_meca_parser(test_data_path, tmp_path):
     test_xml_path = test_data_path / "biorxiv.xml"
     zip_path = tmp_path / "01234.meca"
     with zipfile.ZipFile(zip_path, "w") as myzip:
         myzip.write(test_xml_path, arcname="content/567.xml")
-    parser = MecaParser(zip_path.resolve())
+    parser = JATSXMLParser.from_zip(zip_path.resolve())
 
     return parser
 
@@ -270,8 +269,8 @@ class TestJATSXMLArticleParser:
 
 
 class TestMecaArticleParser:
-    def test_init(self, meca_parser):
-        assert isinstance(meca_parser.content, xml.etree.ElementTree.ElementTree)
+    def test_init(self, jats_meca_parser):
+        assert isinstance(jats_meca_parser.content, xml.etree.ElementTree.ElementTree)
 
     def test_wrong_file(self, test_data_path, tmp_path):
         test_xml_path = test_data_path / "biorxiv.xml"
@@ -280,7 +279,7 @@ class TestMecaArticleParser:
             for i in range(2):
                 myzip.write(test_xml_path, arcname=f"content/{i}.xml")
         with pytest.raises(ValueError):
-            _ = MecaParser(zip_path.resolve())
+            _ = JATSXMLParser.from_zip(zip_path.resolve())
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Fixes #552.

## Description

Please provide here a summary of the changes introduced by this PR.

## How to test?

Please provide here instructions on how to test the changes introduced by this PR.
(if some changes cannot be tested by automated tests)

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
