### PR TITLE
Ignore pytest.PytestUnraisableExceptionWarning globally - fix

### DIFF
--- a/tests/integration/test_bbs_database.py
+++ b/tests/integration/test_bbs_database.py
@@ -130,7 +130,6 @@ def setup_backend(request, tmp_path):
         raise ValueError
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_bbs_database(tmp_path, setup_backend, jsons_path, caplog):
     # Parameters
     db_type, db_url = setup_backend

--- a/tests/unit/database/test_cord_19.py
+++ b/tests/unit/database/test_cord_19.py
@@ -96,7 +96,6 @@ def test_mark_bad_sentences(fake_sqlalchemy_engine):
 class TestDatabaseCreation:
     """Tests the creation of the Database"""
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_database_content(self, real_sqlalchemy_engine):
         """Tests that the two tables expected has been created."""
         inspector = sqlalchemy.inspect(real_sqlalchemy_engine)

--- a/tests/unit/test_embedding_models.py
+++ b/tests/unit/test_embedding_models.py
@@ -41,7 +41,6 @@ from bluesearch.embedding_models import (
 GPU_IS_AVAILABLE = torch.cuda.is_available()
 
 
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestEmbeddingModels:
     """The included tests do not use real models."""
 
@@ -199,7 +198,6 @@ class TestEmbeddingModels:
 # the first test using docker. I tried changing different things in the said
 # fixture, but without success. Last resort solution was to ignore this
 # warning using the decorator below.
-@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("batch_size", [1, 5, 1000])
 def test_compute_database(
     fake_sqlalchemy_engine,

--- a/tox.ini
+++ b/tox.ini
@@ -161,6 +161,7 @@ addopts =
     --verbosity=1
     --last-failed-no-failures=all
     -m "not slow and not network"
+    -p no:unraisableexception
 markers =
     network: tests that require a network connection
     slow: tests that are slow


### PR DESCRIPTION
Fixes #580 

More info: https://docs.pytest.org/en/6.2.x/usage.html?highlight=unraisable#warning-about-unraisable-exceptions-and-unhandled-thread-exceptions