### PR TITLE
Skip download for arXiv articles with broken ID or version

### DIFF
--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -257,11 +257,12 @@ def get_gcs_urls(
 
     url_dict = {}
     for yearmonth in yearmonth_list:
-        iterator = client.list_blobs(bucket, prefix=f"arxiv/arxiv/pdf/{yearmonth}")
+        all_blobs = client.list_blobs(bucket, prefix=f"arxiv/arxiv/pdf/{yearmonth}")
 
         # If more than one version is found, we only keep the last one
+        blobs_info = (_extract_blob_info(blob) for blob in all_blobs)
         df = pd.DataFrame(
-            (_extract_blob_info(blob) for blob in iterator if blob is not None),
+            (info for info in blobs_info if info is not None),
             columns=["blob", "fullname", "article", "version"],
         )
 

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -183,32 +183,42 @@ def test_get_gcs_urls():
     fake_client = Mock()
     fake_bucket = Bucket(fake_client, "my_dir/file.txt")
     fake_blobs_by_prefix = {
+        "arxiv/arxiv/pdf/2109": [
+            Blob("topic-a/99.6767v1.1.pdf", fake_bucket),  # invalid version
+            Blob("topic-v/99.6767v1.2.pdf", fake_bucket),  # invalid version
+            Blob("topic-v/99.6767v1a.pdf", fake_bucket),   # invalid version
+            Blob("topic-v/99.6767v10.pdf", fake_bucket),
+            Blob("topic-v/99.6767v3.pdf", fake_bucket),    # older version
+        ],
         "arxiv/arxiv/pdf/2110": [
-            Blob("topic-a/12.3450v1.pdf", fake_bucket),
+            Blob("topic-a/12.3450v1.pdf", fake_bucket),     # older version
             Blob("topic-v/12.3450v2.pdf", fake_bucket),
         ],
         "arxiv/arxiv/pdf/2111": [
-            Blob("topic-v/99.3450v2.pdf", fake_bucket),
-            Blob("topic-v/99.3450v3.pdf", fake_bucket),
+            Blob("topic-v/99.3450v2.pdf", fake_bucket),     # older version
+            Blob("topic-v/99.3450v3.pdf", fake_bucket),     # older version
             Blob("topic-v/99.3450v10.pdf", fake_bucket),
         ],
         "arxiv/arxiv/pdf/2112": [
             Blob("topic-v/33.1v2.pdf", fake_bucket),
             Blob("topic-v/44.1v2.pdf", fake_bucket),
             Blob("topic-v/55.1v2.pdf", fake_bucket),
-            Blob("topic-v/55.1v1.pdf", fake_bucket),
+            Blob("topic-v/55.1v1.pdf", fake_bucket),        # older version
         ],
     }
 
     fake_client.list_blobs.side_effect = lambda bucket, prefix: fake_blobs_by_prefix[
         prefix
     ]
-    start_date = datetime(2021, 10, 1)
+    start_date = datetime(2021, 9, 1)
     end_date = datetime(2021, 12, 1)
     blobs_by_month = get_gcs_urls(fake_bucket, start_date, end_date)
 
-    assert fake_client.list_blobs.call_count == 3
-    assert set(blobs_by_month) == {"2110", "2111", "2112"}
+    assert fake_client.list_blobs.call_count == 4
+    assert set(blobs_by_month) == {"2109", "2110", "2111", "2112"}
+    assert set(blobs_by_month["2109"]) == set(
+        fake_blobs_by_prefix["arxiv/arxiv/pdf/2109"][-2:-1]
+    )
     assert set(blobs_by_month["2110"]) == set(
         fake_blobs_by_prefix["arxiv/arxiv/pdf/2110"]
     )

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -186,24 +186,24 @@ def test_get_gcs_urls():
         "arxiv/arxiv/pdf/2109": [
             Blob("topic-a/99.6767v1.1.pdf", fake_bucket),  # invalid version
             Blob("topic-v/99.6767v1.2.pdf", fake_bucket),  # invalid version
-            Blob("topic-v/99.6767v1a.pdf", fake_bucket),   # invalid version
+            Blob("topic-v/99.6767v1a.pdf", fake_bucket),  # invalid version
             Blob("topic-v/99.6767v10.pdf", fake_bucket),
-            Blob("topic-v/99.6767v3.pdf", fake_bucket),    # older version
+            Blob("topic-v/99.6767v3.pdf", fake_bucket),  # older version
         ],
         "arxiv/arxiv/pdf/2110": [
-            Blob("topic-a/12.3450v1.pdf", fake_bucket),     # older version
+            Blob("topic-a/12.3450v1.pdf", fake_bucket),  # older version
             Blob("topic-v/12.3450v2.pdf", fake_bucket),
         ],
         "arxiv/arxiv/pdf/2111": [
-            Blob("topic-v/99.3450v2.pdf", fake_bucket),     # older version
-            Blob("topic-v/99.3450v3.pdf", fake_bucket),     # older version
+            Blob("topic-v/99.3450v2.pdf", fake_bucket),  # older version
+            Blob("topic-v/99.3450v3.pdf", fake_bucket),  # older version
             Blob("topic-v/99.3450v10.pdf", fake_bucket),
         ],
         "arxiv/arxiv/pdf/2112": [
             Blob("topic-v/33.1v2.pdf", fake_bucket),
             Blob("topic-v/44.1v2.pdf", fake_bucket),
             Blob("topic-v/55.1v2.pdf", fake_bucket),
-            Blob("topic-v/55.1v1.pdf", fake_bucket),        # older version
+            Blob("topic-v/55.1v1.pdf", fake_bucket),  # older version
         ],
     }
 


### PR DESCRIPTION
Fixes #585.

## Description

This PR fixes the CLI download error caused by arXiv papers with broken ID or version. See comments to #585 for details.

The solution implemented here is to simply skip such problematic papers. This is consistent with the fact that also arXiv cannot retrieve such articles (see e.g. https://arxiv.org/pdf/1808.02949v1.pdf).

## How to test?

Please provide here instructions on how to test the changes introduced by this PR.
(if some changes cannot be tested by automated tests)

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
