### PR TITLE
Support download of `PMC` `oa_other`

### DIFF
--- a/src/bluesearch/database/download.py
+++ b/src/bluesearch/database/download.py
@@ -91,7 +91,7 @@ def generate_pmc_urls(
 
     Parameters
     ----------
-    component : {"author_manuscript", "oa_comm", "oa_noncomm"}
+    component : {"author_manuscript", "oa_comm", "oa_noncomm", "oa_other"}
         Part of the PMC to download.
     start_date
         Starting date to download the incremental files.
@@ -108,16 +108,19 @@ def generate_pmc_urls(
     ValueError
         If the chosen component does not exist on PMC.
     """
-    base_url = "https://ftp.ncbi.nlm.nih.gov/pub/pmc/"
-    if component in {"oa_comm", "oa_noncomm"}:
-        base_url += f"oa_bulk/{component}/xml/"
-    elif component == "author_manuscript":
-        base_url += "manuscript/xml/"
-    else:
+    avail_components = {"author_manuscript", "oa_comm", "oa_noncomm", "oa_other"}
+    if component not in avail_components:
         raise ValueError(
             f"Unexcepted component {component}. "
-            "Only {'author_manuscript', 'oa_comm', 'oa_noncomm'} are supported."
+            f"Only {avail_components} "
+            "are supported."
         )
+
+    base_url = "https://ftp.ncbi.nlm.nih.gov/pub/pmc/"
+    if component == "author_manuscript":
+        base_url += "manuscript/xml/"
+    else:
+        base_url += f"oa_bulk/{component}/xml/"
 
     days_list = get_daterange_list(start_date=start_date, end_date=end_date)
 

--- a/src/bluesearch/entrypoint/database/download.py
+++ b/src/bluesearch/entrypoint/database/download.py
@@ -143,7 +143,8 @@ def run(source: str, from_month: datetime, output_dir: Path, dry_run: bool) -> i
 
     if article_source == ArticleSource.PMC:
         url_dict = {}
-        for component in {"author_manuscript", "oa_comm", "oa_noncomm"}:
+        avail_components = ["author_manuscript", "oa_comm", "oa_noncomm", "oa_other"]
+        for component in avail_components:
             url_dict[component] = generate_pmc_urls(component, from_month)
 
         if dry_run:

--- a/tests/unit/database/test_download.py
+++ b/tests/unit/database/test_download.py
@@ -74,6 +74,7 @@ class TestGetDaterangeList:
         ("author_manuscript", "https://ftp.ncbi.nlm.nih.gov/pub/pmc/manuscript/xml/"),
         ("oa_comm", "https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_bulk/oa_comm/xml/"),
         ("oa_noncomm", "https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_bulk/oa_noncomm/xml/"),
+        ("oa_other", "https://ftp.ncbi.nlm.nih.gov/pub/pmc/oa_bulk/oa_other/xml/"),
     ],
 )
 def test_generate_pmc_urls(monkeypatch, component, expected_url_start):

--- a/tests/unit/entrypoint/database/test_download.py
+++ b/tests/unit/entrypoint/database/test_download.py
@@ -80,6 +80,7 @@ def test_pmc_download(capsys, monkeypatch, tmp_path):
         "author_manuscript",
         "oa_comm",
         "oa_noncomm",
+        "oa_other",
     }
     for sub_dir in pmc_path.iterdir():
         assert len(list(sub_dir.iterdir())) == 2


### PR DESCRIPTION
Partially fixes #584.

## Description

Introduce support for downloading `PMC` articles of `oa_other`.

## How to test?

A dry run of `bbs_database download` will show that also `oa_other` files are downloaded. Just try to run the following:
```bash
bbs_database download -n  pmc 2022-01 .
```

## Checklist

- [x] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [ ] Documentation and `whatsnew.rst` updated.
  (if needed)
- [ ] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [ ] All CI tests pass. 
