### PR TITLE
Trigger CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -155,6 +155,7 @@ filterwarnings =
     ignore::DeprecationWarning:docker.*:
     ignore::DeprecationWarning:luigi.task:
     ignore::DeprecationWarning:transformers.image_utils.*:
+    ignore::UserWarning:luigi.parameter.UnconsumedParameterWarning:
 addopts =
     --cov
     --cov-config=tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,7 @@ filterwarnings =
     ignore::DeprecationWarning:docker.*:
     ignore::DeprecationWarning:luigi.task:
     ignore::DeprecationWarning:transformers.image_utils.*:
-    ignore::UserWarning:luigi.parameter:
+    ignore::luigi.parameter.UnconsumedParameterWarning:
 addopts =
     --cov
     --cov-config=tox.ini

--- a/tox.ini
+++ b/tox.ini
@@ -155,7 +155,7 @@ filterwarnings =
     ignore::DeprecationWarning:docker.*:
     ignore::DeprecationWarning:luigi.task:
     ignore::DeprecationWarning:transformers.image_utils.*:
-    ignore::UserWarning:luigi.parameter.UnconsumedParameterWarning:
+    ignore::UserWarning:luigi.parameter:
 addopts =
     --cov
     --cov-config=tox.ini


### PR DESCRIPTION
CI was failing because of a new Warning from `luigi` package (`luigi.parameter.UnconsumedParameterWarning`)