### PR TITLE
Remove python 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
         include:
           - python-version: 3.8
             tox-env: py38

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,10 +70,8 @@ jobs:
             tox-env: py310
         exclude:
           - python-version: 3.8
-            tox-env: py38
             os: macos-latest
           - python-version: 3.9
-            tox-env: py39
             os: macos-latest
     steps:
       - name: Cancel previous workflows that are still running

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,13 @@ jobs:
             tox-env: py39
           - python-version: 3.10
             tox-env: py310
+        exclude:
+          - python-version: 3.8
+            tox-env: py38
+            os: macos-latest
+          - python-version: 3.9
+            tox-env: py39
+            os: macos-latest
     steps:
       - name: Cancel previous workflows that are still running
         uses: styfle/cancel-workflow-action@0.8.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,14 +60,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
         include:
-          - python-version: 3.7
-            tox-env: py37
           - python-version: 3.8
             tox-env: py38
           - python-version: 3.9
             tox-env: py39
+          - python-version: 3.10
+            tox-env: py310
     steps:
       - name: Cancel previous workflows that are still running
         uses: styfle/cancel-workflow-action@0.8.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
 sources = setup.py src/bluesearch tests benchmarks data_and_models
-envlist = lint, type, py{37, 38, 310}, docs, check-apidoc, check-packaging
+envlist = lint, type, py{38, 39, 310}, docs, check-apidoc, check-packaging
 ; Enable PEP-517/518, https://tox.wiki/en/latest/config.html#conf-isolated_build
 isolated_build = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@
 minversion = 3.1.0
 requires = virtualenv >= 20.0.0
 sources = setup.py src/bluesearch tests benchmarks data_and_models
-envlist = lint, type, py{37, 38, 39}, docs, check-apidoc, check-packaging
+envlist = lint, type, py{37, 38, 310}, docs, check-apidoc, check-packaging
 ; Enable PEP-517/518, https://tox.wiki/en/latest/config.html#conf-isolated_build
 isolated_build = true
 
@@ -34,7 +34,7 @@ commands =
 
 [testenv:lint]
 description = Lint using flake8, black, isort and bandit
-basepython = python3.7
+basepython = python3.8
 skip_install = true
 deps =
     bandit==1.7.0
@@ -53,7 +53,7 @@ commands =
 
 [testenv:type]
 description = Run static type checks using mypy
-basepython = python3.7
+basepython = python3.8
 skip_install = true
 deps =
     mypy==0.910
@@ -79,7 +79,7 @@ commands =
 
 [testenv:docs]
 description = Build docs and run doctest
-basepython = python3.7
+basepython = python3.8
 changedir = docs
 extras = dev
 allowlist_externals = make
@@ -109,7 +109,7 @@ commands =
 
 [testenv:check-packaging]
 description = Generate source and wheel dists and run twine checks
-basepython = python3.7
+basepython = python3.8
 deps =
     setuptools-scm
     wheel


### PR DESCRIPTION
Fixes #636.

## Note

From what I read on internet, I understand that a public repository has 20 concurrent jobs (see [here](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits)) but only 5 `macos` jobs (so it might be still a good idea to remove some python versions for `macos`).

## Checklist

- [X] This PR refers to an issue from the [issue tracker](https://github.com/BlueBrain/Search/issues).
  (if it is not the case, please create an issue first).
- [x] Unit tests added.
  (if needed)
- [x] Documentation and `whatsnew.rst` updated.
  (if needed)
- [x] `setup.py` and `requirements.txt` updated with new dependencies.
  (if needed)
- [x] Type annotations added.
  (if a function is added or modified)
- [x] All CI tests pass. 
